### PR TITLE
lpc55 clippy

### DIFF
--- a/src/areas.rs
+++ b/src/areas.rs
@@ -260,6 +260,12 @@ impl SecureBootCfg {
     }
 }
 
+impl Default for SecureBootCfg {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[repr(C)]
 #[derive(Default, Debug, Clone, PackedStruct)]
 #[packed_struct(size_bytes = "512", bit_numbering = "msb0", endian = "lsb")]
@@ -426,6 +432,12 @@ impl RKTHRevoke {
             rotk3: ROTKeyStatus::Invalid.into(),
             _reserved: ReservedZero::<packed_bits::Bits<24>>::default(),
         }
+    }
+}
+
+impl Default for RKTHRevoke {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/src/areas.rs
+++ b/src/areas.rs
@@ -511,7 +511,7 @@ pub struct CFPAPage {
 
 impl CFPAPage {
     pub fn update_version(&mut self) {
-        self.version = self.version + 1;
+        self.version += 1;
     }
 
     pub fn update_rkth_revoke(&mut self, rkth: RKTHRevoke) -> Result<()> {

--- a/src/areas.rs
+++ b/src/areas.rs
@@ -332,19 +332,18 @@ pub struct CMPAPage {
 
 impl CMPAPage {
     pub fn new(sec_boot_cfg: SecureBootCfg) -> Result<CMPAPage> {
-        let mut p = CMPAPage::default();
-
-        // We're very deliberate about using from_be_bytes here despite
-        // the fact that this is technically going to be an le integer.
-        // packed_struct does not handle endian byte swapping for structres
-        // and the spreadsheet given by NXP gives everything in little
-        // endian form. Many other fields in the structure are marked
-        // little endian so to avoid a double endian swap here we store
-        // the integer as big endian and let the pack() function swap the
-        // endian for us.
-        p.secure_boot_cfg = u32::from_be_bytes(sec_boot_cfg.pack()?);
-
-        Ok(p)
+        Ok(CMPAPage {
+            // We're very deliberate about using from_be_bytes here despite
+            // the fact that this is technically going to be an le integer.
+            // packed_struct does not handle endian byte swapping for structres
+            // and the spreadsheet given by NXP gives everything in little
+            // endian form. Many other fields in the structure are marked
+            // little endian so to avoid a double endian swap here we store
+            // the integer as big endian and let the pack() function swap the
+            // endian for us.
+            secure_boot_cfg: u32::from_be_bytes(sec_boot_cfg.pack()?),
+            ..Default::default()
+        })
     }
 }
 

--- a/src/bin/cfpa-update.rs
+++ b/src/bin/cfpa-update.rs
@@ -25,13 +25,14 @@ fn main() -> Result<()> {
 
     // The target _technically_ has autobaud but it's very flaky
     // and these seem to be the preferred settings
-    let mut settings: SerialPortSettings = Default::default();
-    settings.timeout = Duration::from_millis(1000);
-    settings.baud_rate = 57600;
-    settings.data_bits = DataBits::Eight;
-    settings.flow_control = FlowControl::None;
-    settings.parity = Parity::None;
-    settings.stop_bits = StopBits::One;
+    let settings = SerialPortSettings {
+        timeout: Duration::from_millis(1000),
+        baud_rate: 57600,
+        data_bits: DataBits::Eight,
+        flow_control: FlowControl::None,
+        parity: Parity::None,
+        stop_bits: StopBits::One
+    };
 
     let mut port = serialport::open_with_settings(&args.isp_port, &settings)?;
 

--- a/src/bin/lpc55_flash.rs
+++ b/src/bin/lpc55_flash.rs
@@ -85,7 +85,7 @@ enum ISPCommand {
 
 #[derive(Debug, StructOpt)]
 #[structopt(name = "isp")]
-struct ISP {
+struct Isp {
     /// UART port
     #[structopt(name = "port")]
     port: PathBuf,
@@ -99,7 +99,7 @@ struct ISP {
 }
 
 fn main() -> Result<()> {
-    let cmd = ISP::from_args();
+    let cmd = Isp::from_args();
 
     // The target _technically_ has autobaud but it's very flaky
     // and these seem to be the preferred settings

--- a/src/bin/lpc55_flash.rs
+++ b/src/bin/lpc55_flash.rs
@@ -103,13 +103,14 @@ fn main() -> Result<()> {
 
     // The target _technically_ has autobaud but it's very flaky
     // and these seem to be the preferred settings
-    let mut settings: SerialPortSettings = Default::default();
-    settings.timeout = Duration::from_millis(1000);
-    settings.baud_rate = cmd.baud_rate;
-    settings.data_bits = DataBits::Eight;
-    settings.flow_control = FlowControl::None;
-    settings.parity = Parity::None;
-    settings.stop_bits = StopBits::One;
+    let settings = SerialPortSettings {
+        timeout: Duration::from_millis(1000),
+        baud_rate: cmd.baud_rate,
+        data_bits: DataBits::Eight,
+        flow_control: FlowControl::None,
+        parity: Parity::None,
+        stop_bits: StopBits::One
+    };
 
     let mut port = serialport::open_with_settings(&cmd.port, &settings)?;
 

--- a/src/bin/lpc55_flash.rs
+++ b/src/bin/lpc55_flash.rs
@@ -133,7 +133,7 @@ fn main() -> Result<()> {
                 .create(true)
                 .open(&path)?;
 
-            out.write(&m)?;
+            out.write_all(&m)?;
             println!("Output written to {:?}", path);
         }
         ISPCommand::WriteMemory { address, file } => {
@@ -192,7 +192,7 @@ fn main() -> Result<()> {
                 .create(true)
                 .open(&file)?;
 
-            out.write(&m)?;
+            out.write_all(&m)?;
             println!("CMPA Output written to {:?}", file);
         }
         ISPCommand::ReadCFPA { file } => {
@@ -206,7 +206,7 @@ fn main() -> Result<()> {
                 .create(true)
                 .open(&file)?;
 
-            out.write(&m)?;
+            out.write_all(&m)?;
             println!("CFPA Output written to {:?}", file);
         }
         ISPCommand::Restore => {

--- a/src/bin/lpc55_flash.rs
+++ b/src/bin/lpc55_flash.rs
@@ -227,7 +227,7 @@ fn main() -> Result<()> {
             let mut offset = 4;
             while offset < 0x130 {
                 byteorder::LittleEndian::write_u32(&mut bytes[offset..offset + 4], 0x00000131);
-                offset = offset + 4;
+                offset += 4;
             }
             // This is two branch to self instructions
             byteorder::LittleEndian::write_u32(&mut bytes[0x130..0x134], 0xe7fee7fe);

--- a/src/bin/lpc55_sign.rs
+++ b/src/bin/lpc55_sign.rs
@@ -7,7 +7,7 @@ use structopt::StructOpt;
 enum ImageType {
     /// Generate a non-secure CRC image
     #[structopt(name = "crc")]
-    CRC {
+    Crc {
         #[structopt(parse(from_os_str))]
         src_bin: PathBuf,
         #[structopt(parse(from_os_str))]
@@ -49,7 +49,7 @@ fn main() -> Result<()> {
     let cmd = Images::from_args();
 
     match cmd.cmd {
-        ImageType::CRC { src_bin, dest_bin } => {
+        ImageType::Crc { src_bin, dest_bin } => {
             crc_image::update_crc(&src_bin, &dest_bin)?;
             println!("Done! CRC image written to {:?}", &dest_bin);
         }

--- a/src/isp.rs
+++ b/src/isp.rs
@@ -318,7 +318,7 @@ fn read_ack(port: &mut dyn serialport::SerialPort) -> Result<()> {
     Ok(())
 }
 
-fn check_crc(frame_bytes: &Vec<u8>, response: &Vec<u8>, frame: &FramingPacket) -> Result<()> {
+fn check_crc(frame_bytes: &[u8], response: &[u8], frame: &FramingPacket) -> Result<()> {
     let mut crc = CRCu16::crc16xmodem();
     crc.digest(&frame_bytes[..0x4]);
     crc.digest(&frame_bytes[0x6..]);

--- a/src/isp.rs
+++ b/src/isp.rs
@@ -207,7 +207,7 @@ impl CommandPacket {
         })
     }
 
-    fn to_bytes(self) -> Result<Vec<u8>> {
+    fn to_bytes(&self) -> Result<Vec<u8>> {
         let mut v = Vec::new();
 
         v.extend_from_slice(&self.packet.pack()?);
@@ -253,7 +253,7 @@ impl DataPacket {
         })
     }
 
-    fn to_bytes(self) -> Result<Vec<u8>> {
+    fn to_bytes(&self) -> Result<Vec<u8>> {
         let mut v = Vec::new();
 
         v.extend_from_slice(&self.packet.pack()?);

--- a/src/isp.rs
+++ b/src/isp.rs
@@ -268,7 +268,7 @@ pub fn do_ping(port: &mut dyn serialport::SerialPort) -> Result<()> {
 
     let ping_bytes = ping.pack()?;
 
-    port.write(&ping_bytes)?;
+    port.write_all(&ping_bytes)?;
 
     port.flush()?;
 
@@ -293,7 +293,7 @@ fn send_ack(port: &mut dyn serialport::SerialPort) -> Result<()> {
 
     let bytes = packet.pack()?;
 
-    port.write(&bytes)?;
+    port.write_all(&bytes)?;
     port.flush()?;
 
     Ok(())
@@ -445,7 +445,7 @@ fn send_command(
 
     let command_bytes = command.to_bytes()?;
 
-    port.write(&command_bytes)?;
+    port.write_all(&command_bytes)?;
     port.flush()?;
 
     read_ack(port)?;
@@ -466,7 +466,7 @@ fn send_data(port: &mut dyn serialport::SerialPort, data: Vec<u8>) -> Result<()>
 
         let data_bytes = data_packet.to_bytes()?;
 
-        port.write(&data_bytes)?;
+        port.write_all(&data_bytes)?;
         port.flush()?;
 
         read_ack(port)?;

--- a/src/isp.rs
+++ b/src/isp.rs
@@ -477,12 +477,12 @@ fn send_data(port: &mut dyn serialport::SerialPort, data: Vec<u8>) -> Result<()>
 }
 
 pub fn do_save_keystore(port: &mut dyn serialport::SerialPort) -> Result<()> {
-    let mut args: Vec<u32> = Vec::new();
-
-    // Arg 0 =  WriteNonVolatile
-    args.push(KeyProvisionCmds::WriteNonVolatile as u32);
-    // Arg 1 = Memory ID (0 = internal flash)
-    args.push(0);
+    let args = vec![
+        // Arg 0 =  WriteNonVolatile
+        KeyProvisionCmds::WriteNonVolatile as u32,
+        // Arg 1 = Memory ID (0 = internal flash)
+        0
+    ];
 
     send_command(port, CommandTag::KeyProvision, args)?;
 
@@ -492,10 +492,10 @@ pub fn do_save_keystore(port: &mut dyn serialport::SerialPort) -> Result<()> {
 }
 
 pub fn do_enroll(port: &mut dyn serialport::SerialPort) -> Result<()> {
-    let mut args: Vec<u32> = Vec::new();
-
-    // Arg =  Enroll
-    args.push(KeyProvisionCmds::Enroll as u32);
+    let args = vec![
+        // Arg =  Enroll
+        KeyProvisionCmds::Enroll as u32
+    ];
 
     send_command(port, CommandTag::KeyProvision, args)?;
 
@@ -505,14 +505,14 @@ pub fn do_enroll(port: &mut dyn serialport::SerialPort) -> Result<()> {
 }
 
 pub fn do_generate_uds(port: &mut dyn serialport::SerialPort) -> Result<()> {
-    let mut args: Vec<u32> = Vec::new();
-
-    // Arg 0 =  SetIntrinsicKey
-    args.push(KeyProvisionCmds::SetIntrinsicKey as u32);
-    // Arg 1 = UDS
-    args.push(KeyType::UDS as u32);
-    // Arg 2 = size
-    args.push(32);
+    let args = vec![
+        // Arg 0 =  SetIntrinsicKey
+        KeyProvisionCmds::SetIntrinsicKey as u32,
+        // Arg 1 = UDS
+        KeyType::UDS as u32,
+        // Arg 2 = size
+        32
+    ];
 
     send_command(port, CommandTag::KeyProvision, args)?;
 
@@ -522,9 +522,7 @@ pub fn do_generate_uds(port: &mut dyn serialport::SerialPort) -> Result<()> {
 }
 
 pub fn do_isp_write_keystore(port: &mut dyn serialport::SerialPort, data: Vec<u8>) -> Result<()> {
-    let mut args = Vec::new();
-
-    args.push(KeyProvisionCmds::WriteKeyStore as u32);
+    let args = vec![KeyProvisionCmds::WriteKeyStore as u32];
 
     send_command(port, CommandTag::KeyProvision, args)?;
 
@@ -538,9 +536,7 @@ pub fn do_isp_write_keystore(port: &mut dyn serialport::SerialPort, data: Vec<u8
 }
 
 pub fn do_recv_sb_file(port: &mut dyn serialport::SerialPort, data: Vec<u8>) -> Result<()> {
-    let mut args = Vec::new();
-
-    args.push(data.len() as u32);
+    let args = vec![data.len() as u32];
 
     send_command(port, CommandTag::ReceiveSbFile, args)?;
 
@@ -558,14 +554,14 @@ pub fn do_isp_set_userkey(
     key_type: KeyType,
     data: Vec<u8>,
 ) -> Result<()> {
-    let mut args = Vec::new();
-
-    // Arg0 = Set User Key
-    args.push(KeyProvisionCmds::SetUserKey as u32);
-    // Arg1 =  Key type
-    args.push(key_type as u32);
-    // Arg2 = Key size
-    args.push(data.len() as u32);
+    let args = vec![
+        // Arg0 = Set User Key
+        KeyProvisionCmds::SetUserKey as u32,
+        // Arg1 =  Key type
+        key_type as u32,
+        // Arg2 = Key size
+        data.len() as u32
+    ];
 
     send_command(port, CommandTag::KeyProvision, args)?;
 
@@ -583,11 +579,7 @@ pub fn do_isp_read_memory(
     address: u32,
     cnt: u32,
 ) -> Result<Vec<u8>> {
-    let mut args = Vec::new();
-
-    args.push(address);
-    args.push(cnt);
-    args.push(0x0);
+    let args = vec![address, cnt, 0x0];
 
     send_command(port, CommandTag::ReadMemory, args)?;
 
@@ -614,11 +606,7 @@ pub fn do_isp_write_memory(
     address: u32,
     data: Vec<u8>,
 ) -> Result<()> {
-    let mut args = Vec::new();
-
-    args.push(address);
-    args.push(data.len() as u32);
-    args.push(0x0);
+    let args = vec![address, data.len() as u32, 0x0];
 
     send_command(port, CommandTag::WriteMemory, args)?;
 
@@ -632,10 +620,10 @@ pub fn do_isp_write_memory(
 }
 
 pub fn do_isp_flash_erase_all(port: &mut dyn serialport::SerialPort) -> Result<()> {
-    let mut args: Vec<u32> = Vec::new();
-
-    // Erase internal flash
-    args.push(0x0 as u32);
+    let args = vec![
+        // Erase internal flash
+        0x0_u32
+    ];
 
     send_command(port, CommandTag::FlashEraseAll, args)?;
 

--- a/src/sign_ecc.rs
+++ b/src/sign_ecc.rs
@@ -102,7 +102,7 @@ fn do_ecc_sign_image(binary_path: &Path, priv_key_path: &Path, outfile_path: &Pa
     }
     out.write_all(&new_cert_header.pack()?)?;
     out.write_u32::<byteorder::LittleEndian>((verify_key_point.len()) as u32)?;
-    out.write_all(&verify_key_point.as_bytes())?;
+    out.write_all(verify_key_point.as_bytes())?;
     if cert_pad > 0 {
         out.write_all(&vec![0; cert_pad])?;
     }
@@ -134,5 +134,5 @@ fn do_ecc_sign_image(binary_path: &Path, priv_key_path: &Path, outfile_path: &Pa
 }
 
 pub fn ecc_sign_image(src_bin: &Path, priv_key: &Path, dest_bin: &Path) -> Result<()> {
-    do_ecc_sign_image(&src_bin, &priv_key, &dest_bin)
+    do_ecc_sign_image(src_bin, priv_key, dest_bin)
 }

--- a/src/signed_image.rs
+++ b/src/signed_image.rs
@@ -173,9 +173,9 @@ pub fn sign_image(
     dest_bin: &Path,
     cmpa_dest: &Path,
 ) -> Result<()> {
-    let rkth = do_signed_image(&src_bin, &priv_key, &root_cert0, &dest_bin)?;
+    let rkth = do_signed_image(src_bin, priv_key, root_cert0, dest_bin)?;
 
-    do_cmpa(&cmpa_dest, &rkth)?;
+    do_cmpa(cmpa_dest, &rkth)?;
 
     Ok(())
 }


### PR DESCRIPTION
In my attempts to get the xtask check and clippy support to honor the build target from [package.metadata.build.target] in Cargo.toml I'm cleaning up some low hanging fruit identified by clippy. I've tried to order these from least to most pedantic so you may prefer to ignore some of the later commits by disabling a clippy lint instead.