### PR TITLE
Add section for initial setup of the UART on lpc55xpresso.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,26 @@ This is a crate for accessing things beyond the LPC55 registers, namely support
 for ISP mode programming and structures for the CMPA and CFPA regions. This
 crate also contains some binaries for working with the LPC55
 
+## UART Setup
+
+To use these tools with an lpc55xpresso board it must be in ISP mode. The
+procedure for doing so is documented in the NXP manual. Once your board is in
+ISP mode you'll be able to program various aspects of the device over the UART
+with the commands documented below. Depending on how you want to access the
+UART, some additional steps may be required.
+
+By default the UART is bridged to the LPC-LINK2 probe. When the board is
+powered and the debug link connected, the UART shows up as a USB CDC class
+device. On my Linux system the `usb_cdc` driver creates the device node
+`/dev/ACM0` for it. This device can be used as the `<port>` parameter to the
+commands below.
+
+If you want to use the UART pins (P8) instead you'll need to install a jumper
+on P1. This disables the UART bridge. If you don't have a jumper handy you can
+use the UART through P8 but only if the `Debug Link` / `P6` USB port isn't
+used. Powering the board through one of the other USB ports appears to keep the
+debug link from taking over the UART leaving the P8 pins active but YMMV.
+
 ## `lpc55_flash`
 
 Designed to read/write memory over ISP


### PR DESCRIPTION
TIL the LPC-LINK2 bridges the UART to a USB CDC device and this was
screwing up my FTDI on P8.