### PR TITLE
Allow setting the various DICE fields in the CMPA.

### DIFF
--- a/lpc55_sign/src/areas.rs
+++ b/lpc55_sign/src/areas.rs
@@ -172,6 +172,14 @@ pub enum EnableDiceStatus {
 }
 
 #[derive(PrimitiveEnum, Copy, Clone, Debug)]
+pub enum DiceIncSecEpoch {
+    NotIncluded = 0x0,
+    Included1 = 0x1,
+    Included2 = 0x2,
+    Included3 = 0x3,
+}
+
+#[derive(PrimitiveEnum, Copy, Clone, Debug)]
 pub enum TZMImageStatus {
     InImageHeader = 0x0,
     DisableTZM = 0x1,
@@ -236,8 +244,8 @@ pub struct SecureBootCfg {
     pub block_enroll: EnumCatchAll<EnrollStatus>,
 
     /// Undocumented?
-    #[packed_field(bits = "14..=15")]
-    pub dice_inc_sec_epoch: ReservedZero<packed_bits::Bits<2>>,
+    #[packed_field(ty = "enum", bits = "14..=15")]
+    pub dice_inc_sec_epoch: EnumCatchAll<DiceIncSecEpoch>,
 
     #[packed_field(bits = "29..=16")]
     _reserved: ReservedZero<packed_bits::Bits<14>>,
@@ -257,7 +265,7 @@ impl SecureBootCfg {
             tzm_image_type: TZMImageStatus::InImageHeader.into(),
             block_set_key: SetKeyStatus::EnableKeyCode.into(),
             block_enroll: EnrollStatus::EnableEnroll.into(),
-            dice_inc_sec_epoch: ReservedZero::<packed_bits::Bits<2>>::default(),
+            dice_inc_sec_epoch: DiceIncSecEpoch::NotIncluded.into(),
             _reserved: ReservedZero::<packed_bits::Bits<14>>::default(),
             sec_boot_en: SecBootStatus::PlainImage.into(),
         }

--- a/lpc55_sign/src/bin/lpc55_sign.rs
+++ b/lpc55_sign/src/bin/lpc55_sign.rs
@@ -22,6 +22,12 @@ enum ImageType {
     SignedImage {
         #[clap(long)]
         with_dice: bool,
+        #[clap(long)]
+        with_dice_inc_nxp_cfg: bool,
+        #[clap(long)]
+        with_dice_cust_cfg: bool,
+        #[clap(long)]
+        with_dice_inc_sec_epoch: bool,
         #[clap(parse(from_os_str))]
         src_bin: PathBuf,
         #[clap(parse(from_os_str))]
@@ -61,19 +67,28 @@ fn main() -> Result<()> {
         }
         ImageType::SignedImage {
             with_dice,
+            with_dice_inc_nxp_cfg,
+            with_dice_cust_cfg,
+            with_dice_inc_sec_epoch,
             src_bin,
             priv_key,
             root_cert0,
             dest_bin,
             dest_cmpa,
         } => {
-            signed_image::sign_image(
-                with_dice,
+            let rkth = signed_image::sign_image(
                 &src_bin,
                 &priv_key,
                 &root_cert0,
                 &dest_bin,
-                &dest_cmpa,
+            )?;
+            signed_image::create_cmpa(
+                with_dice,
+                with_dice_inc_nxp_cfg,
+                with_dice_cust_cfg,
+                with_dice_inc_sec_epoch,
+                &rkth,
+                &dest_cmpa
             )?;
             println!(
                 "Done! Signed image written to {:?}, CMPA to {:?}",


### PR DESCRIPTION
Names of variables / parameters have been kept as similar to those from
the spec as possible. These names are pretty awkward but we preserve
them as best we can for consistency.

The `sign_image` function has been split in two: One function to sign
the image and another to generate the CMPA.

NOTE: This commit changes the public API. I've created a companion PR in hubris to use the updated API here: https://github.com/oxidecomputer/hubris/pull/712