### PR TITLE
Add image verification subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,10 +110,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
+name = "cc"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 
 [[package]]
 name = "cfg-if"
@@ -432,6 +444,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "js-sys"
+version = "0.3.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
+dependencies = [
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -470,6 +491,15 @@ checksum = "3c8469b4a23b962c1396b9b451dda50ef5b283e8dd309d69033475fa9b334324"
 dependencies = [
  "libc",
  "pkg-config",
+]
+
+[[package]]
+name = "log"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -662,6 +692,12 @@ checksum = "fe554cb2393bc784fd678c82c84cc0599c31ceadc7f03a594911f822cb8d1815"
 dependencies = [
  "der-parser",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "opaque-debug"
@@ -876,6 +912,21 @@ name = "regex-syntax"
 version = "0.6.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
+
+[[package]]
+name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin",
+ "untrusted",
+ "web-sys",
+ "winapi",
+]
 
 [[package]]
 name = "rsa"
@@ -1129,6 +1180,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
 name = "version_check"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1139,6 +1196,70 @@ name = "wasi"
 version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
+
+[[package]]
+name = "web-sys"
+version = "0.3.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcda906d8be16e728fd5adc5b729afad4e444e106ab28cd1c7256e54fa61510f"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "winapi"
@@ -1193,6 +1314,7 @@ dependencies = [
  "lazy_static",
  "nom",
  "oid-registry",
+ "ring",
  "rusticata-macros",
  "thiserror",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,6 +174,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "colored"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
+dependencies = [
+ "atty",
+ "lazy_static",
+ "winapi",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -546,6 +557,7 @@ dependencies = [
  "anyhow",
  "byteorder",
  "clap",
+ "colored",
  "crc-any",
  "ecdsa",
  "elliptic-curve",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,9 +63,9 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "base64ct"
-version = "1.1.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6b4d9b1225d28d360ec6a231d65af1fd99a2a095154c8040689617290569c5c"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bitfield"
@@ -96,6 +96,15 @@ name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
 dependencies = [
  "generic-array",
 ]
@@ -160,9 +169,9 @@ checksum = "9d6f2aa4d0537bcc1c74df8755072bd31c1ef1a3a1b85a68e8404a8c353b7b8b"
 
 [[package]]
 name = "const-oid"
-version = "0.7.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4c78c047431fee22c1a7bb92e00ad095a02a983affe4d8a72e2a2c62c1b94f3"
+checksum = "520fbf3c07483f94e3e3ca9d0cfd913d7718ef2483d2cfd91c0d9e91474ab913"
 
 [[package]]
 name = "cpufeatures"
@@ -192,16 +201,6 @@ dependencies = [
  "rand_core",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "crypto-bigint"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c6a1d5fa1de37e071642dfa44ec552ca5b299adb128fab16138e24b548fd21"
-dependencies = [
- "generic-array",
- "subtle",
 ]
 
 [[package]]
@@ -247,13 +246,13 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.5.1"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6919815d73839e7ad218de758883aae3a257ba6759ce7a9992501efbb53d705c"
+checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
 dependencies = [
- "const-oid 0.7.1",
- "crypto-bigint 0.3.2",
+ "const-oid 0.9.2",
  "pem-rfc7468",
+ "zeroize",
 ]
 
 [[package]]
@@ -291,10 +290,12 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.3"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
+checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
+ "block-buffer 0.10.3",
+ "const-oid 0.9.2",
  "crypto-common",
 ]
 
@@ -307,7 +308,7 @@ dependencies = [
  "der 0.4.4",
  "elliptic-curve",
  "hmac",
- "signature",
+ "signature 1.3.2",
 ]
 
 [[package]]
@@ -316,7 +317,7 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83e5c176479da93a0983f0a6fdc3c1b8e7d5be0d7fe3fe05a99f15b96582b9a8"
 dependencies = [
- "crypto-bigint 0.2.5",
+ "crypto-bigint",
  "ff",
  "generic-array",
  "group",
@@ -503,7 +504,7 @@ dependencies = [
  "packed_struct_codegen",
  "parse_int",
  "serialport",
- "sha2",
+ "sha2 0.9.8",
  "strum",
  "strum_macros",
 ]
@@ -526,7 +527,7 @@ dependencies = [
  "parse_int",
  "rsa",
  "serde",
- "sha2",
+ "sha2 0.9.8",
  "toml",
  "x509-parser",
 ]
@@ -596,9 +597,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint-dig"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "566d173b2f9406afbc5510a90925d5a2cd80cae4605631f1212303df265de011"
+checksum = "2399c9463abc5f909349d8aa9ba080e0b88b3ce2885389b60b993f39b1a56905"
 dependencies = [
  "byteorder",
  "lazy_static",
@@ -685,7 +686,7 @@ checksum = "d053368e1bae4c8a672953397bd1bd7183dde1c72b0b7612a15719173148d186"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
- "sha2",
+ "sha2 0.9.8",
 ]
 
 [[package]]
@@ -721,21 +722,22 @@ dependencies = [
 
 [[package]]
 name = "pem-rfc7468"
-version = "0.3.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01de5d978f34aa4b2296576379fcc416034702fd94117c56ffd8a1a767cefb30"
+checksum = "24d159833a9105500e0398934e205e0773f0b27529557134ecfc51c27646adac"
 dependencies = [
  "base64ct",
 ]
 
 [[package]]
 name = "pkcs1"
-version = "0.3.3"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a78f66c04ccc83dd4486fd46c33896f4e17b24a7a3a6400dedc48ed0ddd72320"
+checksum = "eff33bdbdfc54cc98a2eca766ebdec3e1b8fb7387523d5c9c9a2891da856f719"
 dependencies = [
- "der 0.5.1",
- "pkcs8 0.8.0",
+ "der 0.6.1",
+ "pkcs8 0.9.0",
+ "spki 0.6.0",
  "zeroize",
 ]
 
@@ -751,13 +753,12 @@ dependencies = [
 
 [[package]]
 name = "pkcs8"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cabda3fb821068a9a4fab19a683eac3af12edf0f34b94a8be53c4972b8149d0"
+checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
 dependencies = [
- "der 0.5.1",
- "spki 0.5.4",
- "zeroize",
+ "der 0.6.1",
+ "spki 0.6.0",
 ]
 
 [[package]]
@@ -843,9 +844,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
 ]
@@ -878,20 +879,21 @@ checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "rsa"
-version = "0.6.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cf22754c49613d2b3b119f0e5d46e34a2c628a937e3024b8762de4e7d8c710b"
+checksum = "55a77d189da1fee555ad95b7e50e7457d91c0e089ec68ca69ad2989413bbdab4"
 dependencies = [
  "byteorder",
- "digest 0.10.3",
+ "digest 0.10.6",
  "num-bigint-dig",
  "num-integer",
  "num-iter",
  "num-traits",
  "pkcs1",
- "pkcs8 0.8.0",
+ "pkcs8 0.9.0",
  "rand_core",
- "smallvec",
+ "sha2 0.10.6",
+ "signature 2.0.0",
  "subtle",
  "zeroize",
 ]
@@ -948,11 +950,22 @@ version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b69f9a4c9740d74c5baa3fd2e547f9525fa8088a8a958e0ca2409a514e33f5fa"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.9.0",
  "cfg-if",
  "cpufeatures",
  "digest 0.9.0",
  "opaque-debug",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -966,10 +979,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "smallvec"
-version = "1.7.0"
+name = "signature"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
+checksum = "8fe458c98333f9c8152221191a77e2a44e8325d0193484af2e9421a53019e57d"
+dependencies = [
+ "digest 0.10.6",
+ "rand_core",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "spin"
@@ -988,12 +1011,12 @@ dependencies = [
 
 [[package]]
 name = "spki"
-version = "0.5.4"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d01ac02a6ccf3e07db148d2be087da624fea0221a16152ed01f0496a6b0a27"
+checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
 dependencies = [
  "base64ct",
- "der 0.5.1",
+ "der 0.6.1",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ FLAGS:
 SUBCOMMANDS:
     crc             Generate a non-secure CRC image
     help            Prints this message or the help of the given subcommand(s)
-    signed-image    Generate a secure saigned image and corresponding CMPA region
+    signed-image    Generate a secure signed image and corresponding CMPA region
 ```
 
 ### Generating a crc image

--- a/lpc55_areas/src/lib.rs
+++ b/lpc55_areas/src/lib.rs
@@ -607,7 +607,7 @@ impl CertHeader {
     }
 }
 
-#[derive(PrimitiveEnum, Copy, Clone, Debug, Deserialize)]
+#[derive(PrimitiveEnum, Copy, Clone, Debug, Deserialize, Eq, PartialEq)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub enum ROTKeyStatus {
     Invalid = 0x0,

--- a/lpc55_areas/src/lib.rs
+++ b/lpc55_areas/src/lib.rs
@@ -9,21 +9,21 @@ use packed_struct::prelude::*;
 use serde::Deserialize;
 
 // Table 183, section 7.3.4
-#[derive(PrimitiveEnum, Copy, Clone, Debug)]
+#[derive(PrimitiveEnum, Copy, Clone, Debug, Eq, PartialEq)]
 pub enum BootImageType {
     PlainImage = 0x0,
     SignedImage = 0x4,
     CRCImage = 0x5,
 }
 
-#[derive(PrimitiveEnum, Copy, Clone, Debug)]
+#[derive(PrimitiveEnum, Copy, Clone, Debug, Eq, PartialEq)]
 pub enum TzmImageType {
     Enabled = 0x0,
     Disabled = 0x1,
 }
 
 // Table 192
-#[derive(PrimitiveEnum, Copy, Clone, Debug)]
+#[derive(PrimitiveEnum, Copy, Clone, Debug, Eq, PartialEq)]
 pub enum TzmPreset {
     NotPresent = 0x0,
     Present = 0x1,
@@ -44,10 +44,7 @@ impl BootField {
     pub fn new(image_type: BootImageType) -> BootField {
         // Table 183, section 7.3.4 for the magic numbers
         BootField {
-            // 0 = TZ-M enabled image. Images are only built
-            // in secure mode at the moment
             tzm_image_type: TzmImageType::Enabled,
-            // 0 = no preset data
             tzm_preset: TzmPreset::NotPresent,
             img_type: image_type.into(),
         }

--- a/lpc55_areas/src/lib.rs
+++ b/lpc55_areas/src/lib.rs
@@ -16,15 +16,28 @@ pub enum BootImageType {
     CRCImage = 0x5,
 }
 
-#[derive(PackedStruct)]
+#[derive(PrimitiveEnum, Copy, Clone, Debug)]
+pub enum TzmImageType {
+    Enabled = 0x0,
+    Disabled = 0x1,
+}
+
+// Table 192
+#[derive(PrimitiveEnum, Copy, Clone, Debug)]
+pub enum TzmPreset {
+    NotPresent = 0x0,
+    Present = 0x1,
+}
+
+#[derive(Debug, PackedStruct)]
 #[packed_struct(size_bytes = "4", bit_numbering = "msb0")]
 pub struct BootField {
     #[packed_field(ty = "enum", bits = "0..8")]
     pub img_type: EnumCatchAll<BootImageType>,
-    #[packed_field(bits = "13")]
-    pub tzm_preset: bool,
-    #[packed_field(bits = "14")]
-    pub tzm_image_type: bool,
+    #[packed_field(ty = "enum", bits = "13")]
+    pub tzm_preset: TzmPreset,
+    #[packed_field(ty = "enum", bits = "14")]
+    pub tzm_image_type: TzmImageType,
 }
 
 impl BootField {
@@ -33,9 +46,9 @@ impl BootField {
         BootField {
             // 0 = TZ-M enabled image. Images are only built
             // in secure mode at the moment
-            tzm_image_type: false,
+            tzm_image_type: TzmImageType::Enabled,
             // 0 = no preset data
-            tzm_preset: false,
+            tzm_preset: TzmPreset::NotPresent,
             img_type: image_type.into(),
         }
     }
@@ -272,63 +285,64 @@ pub enum SecBootStatus {
     SignedImage3 = 0x3,
 }
 
+/// `SECURE_BOOT_CFG` configuration word (`0x3E41C`)
 #[derive(Debug, Clone, PackedStruct)]
 #[packed_struct(size_bytes = "4", endian = "lsb", bit_numbering = "lsb0")]
 pub struct SecureBootCfg {
     /// Can force boot to 4096 bit keys only
     #[packed_field(ty = "enum", bits = "0..=1")]
-    pub rsa4k: EnumCatchAll<RSA4KStatus>,
+    pub rsa4k: RSA4KStatus,
 
     /// Include NXP area in DICE calculation
     #[packed_field(ty = "enum", bits = "2..=3")]
-    pub dice_inc_nxp_cfg: EnumCatchAll<DiceNXPIncStatus>,
+    pub dice_inc_nxp_cfg: DiceNXPIncStatus,
 
     /// Inlcude Customer area in DICE calculation
     #[packed_field(ty = "enum", bits = "4..=5")]
-    pub dice_cust_cfg: EnumCatchAll<DiceCustIncStatus>,
+    pub dice_cust_cfg: DiceCustIncStatus,
 
     /// Enable DICE
     #[packed_field(ty = "enum", bits = "6..=7")]
-    pub skip_dice: EnumCatchAll<EnableDiceStatus>,
+    pub skip_dice: EnableDiceStatus,
 
     /// Choose TZ image type. Similar to the field that's in the image at 0x24
     /// See also why the default is to just use what's in the image
     #[packed_field(ty = "enum", bits = "8..=9")]
-    pub tzm_image_type: EnumCatchAll<TZMImageStatus>,
+    pub tzm_image_type: TZMImageStatus,
 
     /// Block SetKey PUF operation
     #[packed_field(ty = "enum", bits = "10..=11")]
-    pub block_set_key: EnumCatchAll<SetKeyStatus>,
+    pub block_set_key: SetKeyStatus,
 
     /// Block EnrollKey Operationg
     #[packed_field(ty = "enum", bits = "12..=13")]
-    pub block_enroll: EnumCatchAll<EnrollStatus>,
+    pub block_enroll: EnrollStatus,
 
     /// Undocumented?
     #[packed_field(ty = "enum", bits = "14..=15")]
-    pub dice_inc_sec_epoch: EnumCatchAll<DiceIncSecEpoch>,
+    pub dice_inc_sec_epoch: DiceIncSecEpoch,
 
     #[packed_field(bits = "29..=16")]
     _reserved: ReservedZero<packed_bits::Bits<14>>,
 
     /// Enable secure boot
     #[packed_field(ty = "enum", bits = "30..=31")]
-    pub sec_boot_en: EnumCatchAll<SecBootStatus>,
+    pub sec_boot_en: SecBootStatus,
 }
 
 impl SecureBootCfg {
     pub fn new() -> SecureBootCfg {
         SecureBootCfg {
-            rsa4k: RSA4KStatus::RSA2048Keys.into(),
-            dice_inc_nxp_cfg: DiceNXPIncStatus::NotIncluded.into(),
-            dice_cust_cfg: DiceCustIncStatus::NotIncluded.into(),
-            skip_dice: EnableDiceStatus::EnableDice.into(),
-            tzm_image_type: TZMImageStatus::InImageHeader.into(),
-            block_set_key: SetKeyStatus::EnableKeyCode.into(),
-            block_enroll: EnrollStatus::EnableEnroll.into(),
-            dice_inc_sec_epoch: DiceIncSecEpoch::NotIncluded.into(),
+            rsa4k: RSA4KStatus::RSA2048Keys,
+            dice_inc_nxp_cfg: DiceNXPIncStatus::NotIncluded,
+            dice_cust_cfg: DiceCustIncStatus::NotIncluded,
+            skip_dice: EnableDiceStatus::EnableDice,
+            tzm_image_type: TZMImageStatus::InImageHeader,
+            block_set_key: SetKeyStatus::EnableKeyCode,
+            block_enroll: EnrollStatus::EnableEnroll,
+            dice_inc_sec_epoch: DiceIncSecEpoch::NotIncluded,
             _reserved: ReservedZero::<packed_bits::Bits<14>>::default(),
-            sec_boot_en: SecBootStatus::PlainImage.into(),
+            sec_boot_en: SecBootStatus::PlainImage,
         }
     }
 }
@@ -336,33 +350,33 @@ impl SecureBootCfg {
 impl SecureBootCfg {
     pub fn set_dice(&mut self, use_dice: bool) {
         if use_dice {
-            self.skip_dice = EnableDiceStatus::EnableDice.into();
+            self.skip_dice = EnableDiceStatus::EnableDice;
         } else {
-            self.skip_dice = EnableDiceStatus::DisableDice1.into();
+            self.skip_dice = EnableDiceStatus::DisableDice1;
         }
     }
 
     pub fn set_dice_inc_nxp_cfg(&mut self, use_nxp_cfg: bool) {
         if use_nxp_cfg {
-            self.dice_inc_nxp_cfg = DiceNXPIncStatus::Included1.into();
+            self.dice_inc_nxp_cfg = DiceNXPIncStatus::Included1;
         }
     }
 
     pub fn set_dice_inc_cust_cfg(&mut self, use_cust_cfg: bool) {
         if use_cust_cfg {
-            self.dice_cust_cfg = DiceCustIncStatus::Included1.into();
+            self.dice_cust_cfg = DiceCustIncStatus::Included1;
         }
     }
 
     pub fn set_dice_inc_sec_epoch(&mut self, inc_sec_epoch: bool) {
         if inc_sec_epoch {
-            self.dice_inc_sec_epoch = DiceIncSecEpoch::Included1.into();
+            self.dice_inc_sec_epoch = DiceIncSecEpoch::Included1;
         }
     }
 
     pub fn set_sec_boot(&mut self, sec_boot: bool) {
         if sec_boot {
-            self.sec_boot_en = SecBootStatus::SignedImage3.into();
+            self.sec_boot_en = SecBootStatus::SignedImage3;
         }
     }
 }
@@ -620,16 +634,16 @@ impl ROTKeyStatus {
 #[packed_struct(size_bytes = "4", endian = "lsb", bit_numbering = "lsb0")]
 pub struct RKTHRevoke {
     #[packed_field(ty = "enum", bits = "1..=0")]
-    pub rotk0: EnumCatchAll<ROTKeyStatus>,
+    pub rotk0: ROTKeyStatus,
 
     #[packed_field(ty = "enum", bits = "3..=2")]
-    pub rotk1: EnumCatchAll<ROTKeyStatus>,
+    pub rotk1: ROTKeyStatus,
 
     #[packed_field(ty = "enum", bits = "5..=4")]
-    pub rotk2: EnumCatchAll<ROTKeyStatus>,
+    pub rotk2: ROTKeyStatus,
 
     #[packed_field(ty = "enum", bits = "7..=6")]
-    pub rotk3: EnumCatchAll<ROTKeyStatus>,
+    pub rotk3: ROTKeyStatus,
 
     #[packed_field(bits = "31..=8")]
     _reserved: ReservedZero<packed_bits::Bits<24>>,
@@ -638,47 +652,47 @@ pub struct RKTHRevoke {
 impl RKTHRevoke {
     pub fn new() -> RKTHRevoke {
         RKTHRevoke {
-            rotk0: ROTKeyStatus::Invalid.into(),
-            rotk1: ROTKeyStatus::Invalid.into(),
-            rotk2: ROTKeyStatus::Invalid.into(),
-            rotk3: ROTKeyStatus::Invalid.into(),
+            rotk0: ROTKeyStatus::Invalid,
+            rotk1: ROTKeyStatus::Invalid,
+            rotk2: ROTKeyStatus::Invalid,
+            rotk3: ROTKeyStatus::Invalid,
             _reserved: ReservedZero::<packed_bits::Bits<24>>::default(),
         }
     }
 
     pub fn enable_keys(&mut self, key0: bool, key1: bool, key2: bool, key3: bool) {
         if key0 {
-            self.rotk0 = ROTKeyStatus::Enabled.into();
+            self.rotk0 = ROTKeyStatus::Enabled;
         }
 
         if key1 {
-            self.rotk1 = ROTKeyStatus::Enabled.into();
+            self.rotk1 = ROTKeyStatus::Enabled;
         }
 
         if key2 {
-            self.rotk2 = ROTKeyStatus::Enabled.into();
+            self.rotk2 = ROTKeyStatus::Enabled;
         }
 
         if key3 {
-            self.rotk3 = ROTKeyStatus::Enabled.into();
+            self.rotk3 = ROTKeyStatus::Enabled;
         }
     }
 
     pub fn revoke_keys(&mut self, key0: bool, key1: bool, key2: bool, key3: bool) {
         if key0 {
-            self.rotk0 = ROTKeyStatus::Revoked2.into();
+            self.rotk0 = ROTKeyStatus::Revoked2;
         }
 
         if key1 {
-            self.rotk1 = ROTKeyStatus::Revoked2.into();
+            self.rotk1 = ROTKeyStatus::Revoked2;
         }
 
         if key2 {
-            self.rotk2 = ROTKeyStatus::Revoked2.into();
+            self.rotk2 = ROTKeyStatus::Revoked2;
         }
 
         if key3 {
-            self.rotk3 = ROTKeyStatus::Revoked2.into();
+            self.rotk3 = ROTKeyStatus::Revoked2;
         }
     }
 }
@@ -742,7 +756,7 @@ pub struct CFPAPage {
     pub cmpa_prog_in_progress: u32,
 
     // prince security codes. These are split up to get around rust's
-    // limitation of 256 byte arrays
+    // limitation of not deriving Default for >256 byte arrays
     pub prince_region0_code0: [u8; 0x20],
     pub prince_region0_code1: [u8; 0x18],
     pub prince_region1_code0: [u8; 0x20],

--- a/lpc55_sign/Cargo.toml
+++ b/lpc55_sign/Cargo.toml
@@ -18,7 +18,7 @@ hex = "0.4.3"
 crc-any = "2.3.5"
 x509-parser = "0.12.0"
 sha2 = "0.9.8"
-rsa = "0.6.1"
+rsa = { version = "0.8.1", features = ["sha2"] }
 lpc55_areas = { path = "../lpc55_areas", features = [] }
 serde = { version = "1", features = ["derive"] }
 toml = "0.5.6"

--- a/lpc55_sign/Cargo.toml
+++ b/lpc55_sign/Cargo.toml
@@ -23,6 +23,7 @@ lpc55_areas = { path = "../lpc55_areas", features = [] }
 serde = { version = "1", features = ["derive"] }
 toml = "0.5.6"
 parse_int = "0.6.0"
+colored = "2.0"
 
 [features]
 default = ["binaries"]

--- a/lpc55_sign/Cargo.toml
+++ b/lpc55_sign/Cargo.toml
@@ -16,7 +16,7 @@ p256 = "0.9.0"
 elliptic-curve = { version = "0.10.4", default-features = false }
 hex = "0.4.3"
 crc-any = "2.3.5"
-x509-parser = "0.12.0"
+x509-parser = { version = "0.12.0", features = ["verify"] }
 sha2 = "0.9.8"
 rsa = { version = "0.8.1", features = ["sha2"] }
 lpc55_areas = { path = "../lpc55_areas", features = [] }

--- a/lpc55_sign/src/bin/lpc55_sign.rs
+++ b/lpc55_sign/src/bin/lpc55_sign.rs
@@ -397,12 +397,17 @@ fn check_signed_image(image: &[u8], cmpa: CMPAPage, verbose: bool) -> Result<()>
         let cert = &image[start..start + x509_length as usize];
 
         let (_, cert) = x509_parser::parse_x509_certificate(cert)?;
-        println!("    ✅ successfully parsed certificate");
+        println!("    ✅ Successfully parsed certificate");
 
         let prev_public_key = certs.last().map(|prev| prev.public_key());
+        let kind = if prev_public_key.is_some() {
+            "chained"
+        } else {
+            "self-signed"
+        };
         match cert.verify_signature(prev_public_key) {
-            Ok(()) => println!("    ✅ Verified certificate signature"),
-            Err(e) => println!("    ❌ Failed to verify certificate signature: {e:?}"),
+            Ok(()) => println!("    ✅ Verified {kind} certificate signature"),
+            Err(e) => println!("    ❌ Failed to verify {kind} certificate signature: {e:?}"),
         }
 
         certs.push(cert);

--- a/lpc55_sign/src/bin/lpc55_sign.rs
+++ b/lpc55_sign/src/bin/lpc55_sign.rs
@@ -430,6 +430,14 @@ fn check_signed_image(image: &[u8], cmpa: CMPAPage, cfpa: CFPAPage, verbose: boo
 
         let (_, cert) = x509_parser::parse_x509_certificate(cert)?;
         check!(OK, "    Successfully parsed certificate");
+        println!(
+            "    Subject:\n      {}",
+            cert.subject().to_string().replace(", ", "\n      ")
+        );
+        println!(
+            "    Issuer:\n      {}",
+            cert.issuer().to_string().replace(", ", "\n      ")
+        );
 
         let prev_public_key = certs.last().map(|prev| prev.public_key());
         let kind = if prev_public_key.is_some() {

--- a/lpc55_sign/src/bin/lpc55_sign.rs
+++ b/lpc55_sign/src/bin/lpc55_sign.rs
@@ -281,7 +281,7 @@ fn main() -> Result<()> {
             match secure_boot_cfg.tzm_image_type {
                 TZMImageStatus::PresetTZM => {
                     if matches!(image_type.tzm_preset, TzmPreset::NotPresent) {
-                        println!("    🚫 CFPA requires TZ preset, but image header says it is not present");
+                        println!("    ❌ CFPA requires TZ preset, but image header says it is not present");
                     } else {
                         todo!("don't yet know how to decode TZ preset");
                     }
@@ -300,11 +300,11 @@ fn main() -> Result<()> {
                 TZMImageStatus::DisableTZM => {
                     if matches!(image_type.tzm_image_type, TzmImageType::Enabled) {
                         println!(
-                            "    🚫 CFPA requires TZ disabled, but image header says it is enabled"
+                            "    ❌ CFPA requires TZ disabled, but image header says it is enabled"
                         );
                     } else if matches!(image_type.tzm_preset, TzmPreset::Present) {
                         println!(
-                            "    🚫 CFPA requires TZ disabled, but image header has tzm_preset"
+                            "    ❌ CFPA requires TZ disabled, but image header has tzm_preset"
                         );
                     } else {
                         println!("    ✅ TZM disabled in CMPA and in image header");
@@ -313,7 +313,7 @@ fn main() -> Result<()> {
                 TZMImageStatus::EnableTZM => {
                     if matches!(image_type.tzm_image_type, TzmImageType::Disabled) {
                         println!(
-                            "    🚫 CFPA requires TZ enabled, but image header says it is disabled"
+                            "    ❌ CFPA requires TZ enabled, but image header says it is disabled"
                         );
                     } else if matches!(image_type.tzm_preset, TzmPreset::Present) {
                         todo!("don't yet know how to decode TZ preset");
@@ -331,13 +331,13 @@ fn main() -> Result<()> {
                 }
                 EnumCatchAll::Enum(BootImageType::CRCImage) => {
                     if secure_boot_enabled {
-                        println!("🚫 Secure boot enabled in CPFA, but this is a CRC image");
+                        println!("❌ Secure boot enabled in CPFA, but this is a CRC image");
                     }
                     check_crc_image(&image)?
                 }
                 EnumCatchAll::Enum(BootImageType::PlainImage) => {
                     if secure_boot_enabled {
-                        println!("🚫 Secure boot enabled in CPFA, but this is a plain image");
+                        println!("❌ Secure boot enabled in CPFA, but this is a plain image");
                     }
                     check_plain_image(&image)?
                 }
@@ -365,7 +365,7 @@ fn check_signed_image(image: &[u8], cmpa: CMPAPage, verbose: bool) -> Result<()>
     }
 
     if cert_header.signature != *b"cert" {
-        println!("🚫 Certificate header does not begin with 'cert'");
+        println!("❌ Certificate header does not begin with 'cert'");
     }
 
     if cert_header.total_image_len != header_offset + cert_header.header_length {
@@ -397,7 +397,7 @@ fn check_signed_image(image: &[u8], cmpa: CMPAPage, verbose: bool) -> Result<()>
         let prev_public_key = certs.last().map(|prev| prev.public_key());
         match cert.verify_signature(prev_public_key) {
             Ok(()) => println!("    ✅ Verified certificate signature"),
-            Err(e) => println!("    🚫 Failed to verify certificate signature: {e:?}"),
+            Err(e) => println!("    ❌ Failed to verify certificate signature: {e:?}"),
         }
 
         certs.push(cert);
@@ -423,7 +423,7 @@ fn check_signed_image(image: &[u8], cmpa: CMPAPage, verbose: bool) -> Result<()>
     }
 
     if rkh_sha.finalize().as_slice() != cmpa.rotkh {
-        println!("🚫 RKH in CMPA does not match Root Key hashes in image");
+        println!("❌ RKH in CMPA does not match Root Key hashes in image");
     } else {
         println!("✅ RKH in CMPA matches Root Key hashes in image");
     }
@@ -435,7 +435,7 @@ fn check_signed_image(image: &[u8], cmpa: CMPAPage, verbose: bool) -> Result<()>
     sha.update(public_key_rsa.e().to_bytes_be());
     let out = sha.finalize().to_vec();
     if !rkh_table.contains(&out) {
-        println!("🚫 Certificate 0's public key is not in RKH table");
+        println!("❌ Certificate 0's public key is not in RKH table");
     } else {
         println!("✅ Certificate 0's public key is in RKH table");
     }
@@ -455,7 +455,7 @@ fn check_signed_image(image: &[u8], cmpa: CMPAPage, verbose: bool) -> Result<()>
         rsa::pkcs1v15::VerifyingKey::<rsa::sha2::Sha256>::new_with_prefix(public_key_rsa);
     match verifying_key.verify(&image[..start], &signature) {
         Ok(()) => println!("✅ Verified signature against last certificate"),
-        Err(e) => println!("🚫 Failed to verify signature: {e:?}"),
+        Err(e) => println!("❌ Failed to verify signature: {e:?}"),
     }
     Ok(())
 }
@@ -469,7 +469,7 @@ fn check_crc_image(image: &[u8]) -> Result<()> {
     if expected == actual {
         println!("✅ CRC32 matches");
     } else {
-        println!("🚫 CRC32 does not match");
+        println!("❌ CRC32 does not match");
     }
     Ok(())
 }

--- a/lpc55_sign/src/bin/lpc55_sign.rs
+++ b/lpc55_sign/src/bin/lpc55_sign.rs
@@ -281,7 +281,7 @@ fn main() -> Result<()> {
             match secure_boot_cfg.tzm_image_type {
                 TZMImageStatus::PresetTZM => {
                     if matches!(image_type.tzm_preset, TzmPreset::NotPresent) {
-                        println!("    ⚠️  CFPA requires TZ preset, but image header says it is not present");
+                        println!("    🚫 CFPA requires TZ preset, but image header says it is not present");
                     } else {
                         todo!("don't yet know how to decode TZ preset");
                     }
@@ -300,11 +300,11 @@ fn main() -> Result<()> {
                 TZMImageStatus::DisableTZM => {
                     if matches!(image_type.tzm_image_type, TzmImageType::Enabled) {
                         println!(
-                            "    ⚠️  CFPA requires TZ disabled, but image header says it is enabled"
+                            "    🚫 CFPA requires TZ disabled, but image header says it is enabled"
                         );
                     } else if matches!(image_type.tzm_preset, TzmPreset::Present) {
                         println!(
-                            "    ⚠️  CFPA requires TZ disabled, but image header has tzm_preset"
+                            "    🚫 CFPA requires TZ disabled, but image header has tzm_preset"
                         );
                     } else {
                         println!("    ✅ TZM disabled in CMPA and in image header");
@@ -313,7 +313,7 @@ fn main() -> Result<()> {
                 TZMImageStatus::EnableTZM => {
                     if matches!(image_type.tzm_image_type, TzmImageType::Disabled) {
                         println!(
-                            "    ⚠️  CFPA requires TZ enabled, but image header says it is disabled"
+                            "    🚫 CFPA requires TZ enabled, but image header says it is disabled"
                         );
                     } else if matches!(image_type.tzm_preset, TzmPreset::Present) {
                         todo!("don't yet know how to decode TZ preset");
@@ -331,13 +331,13 @@ fn main() -> Result<()> {
                 }
                 EnumCatchAll::Enum(BootImageType::CRCImage) => {
                     if secure_boot_enabled {
-                        println!("⚠️  Secure boot enabled in CPFA, but this is a CRC image");
+                        println!("🚫 Secure boot enabled in CPFA, but this is a CRC image");
                     }
                     check_crc_image(&image)?
                 }
                 EnumCatchAll::Enum(BootImageType::PlainImage) => {
                     if secure_boot_enabled {
-                        println!("⚠️  Secure boot enabled in CPFA, but this is a plain image");
+                        println!("🚫 Secure boot enabled in CPFA, but this is a plain image");
                     }
                     check_plain_image(&image)?
                 }
@@ -365,7 +365,7 @@ fn check_signed_image(image: &[u8], cmpa: CMPAPage, verbose: bool) -> Result<()>
     }
 
     if cert_header.signature != *b"cert" {
-        println!("⚠️  cert header does not begin with 'cert'");
+        println!("🚫 Certificate header does not begin with 'cert'");
     }
 
     if cert_header.total_image_len != header_offset + cert_header.header_length {
@@ -397,7 +397,7 @@ fn check_signed_image(image: &[u8], cmpa: CMPAPage, verbose: bool) -> Result<()>
         let prev_public_key = certs.last().map(|prev| prev.public_key());
         match cert.verify_signature(prev_public_key) {
             Ok(()) => println!("    ✅ Verified certificate signature"),
-            Err(e) => println!("    ⚠️  Failed to verify certificate signature: {e:?}"),
+            Err(e) => println!("    🚫 Failed to verify certificate signature: {e:?}"),
         }
 
         certs.push(cert);
@@ -423,7 +423,7 @@ fn check_signed_image(image: &[u8], cmpa: CMPAPage, verbose: bool) -> Result<()>
     }
 
     if rkh_sha.finalize().as_slice() != cmpa.rotkh {
-        println!("⚠️  RKH in CMPA does not match Root Key hashes in image");
+        println!("🚫 RKH in CMPA does not match Root Key hashes in image");
     } else {
         println!("✅ RKH in CMPA matches Root Key hashes in image");
     }
@@ -435,7 +435,7 @@ fn check_signed_image(image: &[u8], cmpa: CMPAPage, verbose: bool) -> Result<()>
     sha.update(public_key_rsa.e().to_bytes_be());
     let out = sha.finalize().to_vec();
     if !rkh_table.contains(&out) {
-        println!("⚠️  Certificate 0's public key is not in RKH table");
+        println!("🚫 Certificate 0's public key is not in RKH table");
     } else {
         println!("✅ Certificate 0's public key is in RKH table");
     }
@@ -455,7 +455,7 @@ fn check_signed_image(image: &[u8], cmpa: CMPAPage, verbose: bool) -> Result<()>
         rsa::pkcs1v15::VerifyingKey::<rsa::sha2::Sha256>::new_with_prefix(public_key_rsa);
     match verifying_key.verify(&image[..start], &signature) {
         Ok(()) => println!("✅ Verified signature against last certificate"),
-        Err(e) => println!("⚠️  Failed to verify signature: {e:?}"),
+        Err(e) => println!("🚫 Failed to verify signature: {e:?}"),
     }
     Ok(())
 }
@@ -469,7 +469,7 @@ fn check_crc_image(image: &[u8]) -> Result<()> {
     if expected == actual {
         println!("✅ CRC32 matches");
     } else {
-        println!("⚠️  CRC32 does not match");
+        println!("🚫 CRC32 does not match");
     }
     Ok(())
 }

--- a/lpc55_sign/src/bin/lpc55_sign.rs
+++ b/lpc55_sign/src/bin/lpc55_sign.rs
@@ -326,7 +326,7 @@ fn main() -> Result<()> {
             }
 
             if rkh_sha.finalize().as_slice() != cmpa.rotkh {
-                println!("⚠️  Certificate 0's public key is not in RKH table");
+                println!("⚠️  RKH in CMPA does not match Root Key hashes in image");
             } else {
                 println!("✅ RKH in CMPA matches Root Key hashes in image");
             }

--- a/lpc55_sign/src/bin/lpc55_sign.rs
+++ b/lpc55_sign/src/bin/lpc55_sign.rs
@@ -366,14 +366,19 @@ fn check_signed_image(image: &[u8], cmpa: CMPAPage, verbose: bool) -> Result<()>
 
     if cert_header.signature != *b"cert" {
         println!("❌ Certificate header does not begin with 'cert'");
+    } else {
+        println!("✅ Verified certificate header signature ('cert')");
     }
 
-    if cert_header.total_image_len != header_offset + cert_header.header_length {
+    let expected_len =
+        header_offset + cert_header.header_length + cert_header.certificate_table_len + 32 * 4;
+    if cert_header.total_image_len != expected_len {
         println!(
-            "⚠️  mismatched lengths (?) ({} != {})",
-            cert_header.total_image_len,
-            header_offset + cert_header.header_length
+            "❌ Invalid image length in cert header: expected {expected_len}, got {}",
+            cert_header.total_image_len
         );
+    } else {
+        println!("✅ Verified certificate header length");
     }
 
     let mut start = (header_offset + cert_header.header_length) as usize;

--- a/lpc55_sign/src/signed_image.rs
+++ b/lpc55_sign/src/signed_image.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use byteorder::{ByteOrder, WriteBytesExt};
 use lpc55_areas::*;
 use rsa::{
@@ -79,7 +79,10 @@ pub fn sign_chain(
         .cert_paths
         .iter()
         .flat_map(|path| {
-            let cert_bytes = std::fs::read(prefix.join(path)).unwrap();
+            let full_path = prefix.join(path);
+            let cert_bytes = std::fs::read(&full_path)
+                .with_context(|| format!("could not load cert at {full_path:?}"))
+                .unwrap();
             let cert_pad = get_pad(cert_bytes.len());
             let padded_len = cert_bytes.len() + cert_pad;
             let mut v = Vec::new();


### PR DESCRIPTION
The meat of this PR is in `lpc55_sign/src/bin/lpc55_sign.rs`, which grows a brand new `verify-image` subcommand.

Here's what it looks like in action:
```console
$ cargo run -plpc55_sign -- verify-signed-image chained.cmpa example-stage0-secure/CFPA.bin chained.bin
    Finished dev [unoptimized + debuginfo] target(s) in 0.07s
     Running `target/debug/lpc55_sign verify-signed-image chained.cmpa example-stage0-secure/CFPA.bin chained.bin`
=== CMPA ====
No CMPA verification implemented
=== CFPA ====
No CFPA verification implemented
=== Image ====
⚠️  Load address is 0 in a non-plain image
Checking TZM configuration
    ✅ TZM enabled in image header, without preset data
✅ Verified certificate header signature ('cert')
✅ Verified certificate header length
Checking certificate [1/2]
    ✅ successfully parsed certificate
    ✅ Verified certificate signature
Checking certificate [2/2]
    ✅ successfully parsed certificate
    ✅ Verified certificate signature
✅ RKH in CMPA matches Root Key hashes in image
✅ Certificate 0's public key is in RKH table
✅ Verified signature against last certificate
```

There are also a handful of drive-by changes:
- Bump the `sha` crate (necessary for verification) and fix API changes 
- Remove the use of `EnumCatchAll` in cases where the `enum` is exhausive (e.g. a two-bit field with four enum values); this makes matching in `lpc55_sign.rs` less verbose.
- Various `clippy` fixes