### PR TITLE
Fixes from alt-stage0 work

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -483,7 +483,7 @@ dependencies = [
  "num-traits",
  "packed_struct",
  "packed_struct_codegen",
- "parse_int 0.4.0",
+ "parse_int",
  "serde",
 ]
 
@@ -501,7 +501,7 @@ dependencies = [
  "num-traits",
  "packed_struct",
  "packed_struct_codegen",
- "parse_int 0.4.0",
+ "parse_int",
  "serialport",
  "sha2",
  "strum",
@@ -523,7 +523,7 @@ dependencies = [
  "p256",
  "packed_struct",
  "packed_struct_codegen",
- "parse_int 0.6.0",
+ "parse_int",
  "rsa",
  "serde",
  "sha2",
@@ -708,15 +708,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "parse_int"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82db48cac18f0963b10ddad303fa88447b95bbe0e6dbe3385f98402b63d0cc48"
-dependencies = [
- "num-traits",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -483,7 +483,7 @@ dependencies = [
  "num-traits",
  "packed_struct",
  "packed_struct_codegen",
- "parse_int",
+ "parse_int 0.4.0",
  "serde",
 ]
 
@@ -501,7 +501,7 @@ dependencies = [
  "num-traits",
  "packed_struct",
  "packed_struct_codegen",
- "parse_int",
+ "parse_int 0.4.0",
  "serialport",
  "sha2",
  "strum",
@@ -523,6 +523,7 @@ dependencies = [
  "p256",
  "packed_struct",
  "packed_struct_codegen",
+ "parse_int 0.6.0",
  "rsa",
  "serde",
  "sha2",
@@ -714,6 +715,15 @@ name = "parse_int"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82db48cac18f0963b10ddad303fa88447b95bbe0e6dbe3385f98402b63d0cc48"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "parse_int"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d695b79916a2c08bcff7be7647ab60d1402885265005a6658ffe6d763553c5a"
 dependencies = [
  "num-traits",
 ]

--- a/lpc55_areas/Cargo.toml
+++ b/lpc55_areas/Cargo.toml
@@ -11,7 +11,7 @@ packed_struct_codegen = "0.10.0"
 anyhow = "1.0.32"
 byteorder = "1.3.4"
 hex = "0.4.3"
-parse_int = "0.4.0"
+parse_int = "0.6.0"
 num-derive = { version = "0.3.0", features = [ "full-syntax" ] }
 num-traits = "0.2.14"
 bitfield = "0.14.0"

--- a/lpc55_areas/src/lib.rs
+++ b/lpc55_areas/src/lib.rs
@@ -749,10 +749,6 @@ pub struct CFPAPage {
 }
 
 impl CFPAPage {
-    pub fn update_version(&mut self) {
-        self.version += 1;
-    }
-
     pub fn set_debug_fields(&mut self, settings: DebugSettings) -> Result<()> {
         self.dcfg_cc_socu_ns_pin = settings.pin();
         self.dcfg_cc_socu_ns_dflt = settings.dflt();

--- a/lpc55_isp/Cargo.toml
+++ b/lpc55_isp/Cargo.toml
@@ -14,7 +14,7 @@ crc-any = "2.3.5"
 byteorder = "1.3.4"
 clap = { version = "3.0.14", features = ["derive"] }
 hex = "0.4.3"
-parse_int = "0.4.0"
+parse_int = "0.6.0"
 lpc55_areas = { path = "../lpc55_areas", features = [] }
 sha2 = "0.9.8"
 num-derive = { version = "0.3.0", features = [ "full-syntax" ] }

--- a/lpc55_isp/src/bin/cfpa-update.rs
+++ b/lpc55_isp/src/bin/cfpa-update.rs
@@ -51,7 +51,7 @@ fn main() -> Result<()> {
     let mut cfpa: CFPAPage = CFPAPage::unpack(&cfpa)?;
 
     // We always need to bump the version
-    cfpa.update_version();
+    cfpa.version += 1;
 
     let mut rkth = RKTHRevoke::new();
 

--- a/lpc55_isp/src/bin/lpc55_flash.rs
+++ b/lpc55_isp/src/bin/lpc55_flash.rs
@@ -38,6 +38,13 @@ enum ISPCommand {
     /// Erases all non-secure flash. This MUST be done before writing!
     #[clap(name = "flash-erase-all")]
     FlashEraseAll,
+    /// Erases a portion of non-secure flash. This MUST be done before writing!
+    FlashEraseRegion {
+        #[clap(parse(try_from_str = parse_int::parse))]
+        start_address: u32,
+        #[clap(parse(try_from_str = parse_int::parse))]
+        byte_count: u32,
+    },
     /// Write a file to the CMPA region
     #[clap(name = "write-cmpa")]
     WriteCMPA {
@@ -280,6 +287,16 @@ fn main() -> Result<()> {
             do_isp_flash_erase_all(&mut *port)?;
 
             println!("Flash erased!");
+        }
+        ISPCommand::FlashEraseRegion {
+            start_address,
+            byte_count,
+        } => {
+            do_ping(&mut *port)?;
+
+            do_isp_flash_erase_region(&mut *port, start_address, byte_count)?;
+
+            println!("Flash region erased!");
         }
         // Yes this is just another write-memory call but remembering addresses
         // is hard.

--- a/lpc55_isp/src/bin/lpc55_flash.rs
+++ b/lpc55_isp/src/bin/lpc55_flash.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use anyhow::Result;
+use anyhow::{bail, Context, Result};
 use byteorder::ByteOrder;
 use clap::Parser;
 use lpc55_isp::cmd::*;
@@ -61,6 +61,13 @@ enum ISPCommand {
     },
     /// Save the CFPA region to a file
     ReadCFPA {
+        #[clap(parse(from_os_str))]
+        file: PathBuf,
+    },
+    /// Write the CFPA region from the contents of a file.
+    WriteCFPA {
+        #[clap(short, long)]
+        update_version: bool,
         #[clap(parse(from_os_str))]
         file: PathBuf,
     },
@@ -349,6 +356,57 @@ fn main() -> Result<()> {
 
             out.write_all(&m)?;
             println!("CFPA Output written to {:?}", file);
+        }
+        ISPCommand::WriteCFPA {
+            update_version,
+            file,
+        } => {
+            do_ping(&mut *port)?;
+
+            let bytes = std::fs::read(&file)?;
+            let mut new_cfpa = lpc55_areas::CFPAPage::from_bytes(
+                bytes[..].try_into().context("CFPA file is not 512 bytes")?,
+            )?;
+
+            // Read the CMPA so we can compare the two to try to avoid locking
+            // the user out of their chip.
+            let m = do_isp_read_memory(&mut *port, 0x9e400, 512)?;
+            let cmpa = lpc55_areas::CMPAPage::from_bytes(m[..].try_into().unwrap())?;
+            if (new_cfpa.dcfg_cc_socu_ns_pin != 0 || new_cfpa.dcfg_cc_socu_ns_dflt != 0)
+                && (cmpa.cc_socu_pin == 0 || cmpa.cc_socu_dflt == 0)
+            {
+                bail!(
+                    "It looks like the CMPA debug settings aren't set but \
+                     the CFPA settings are! This will brick the chip!"
+                );
+                // TODO I guess it's remotely possible that we might want an
+                // override for this check.
+            }
+
+            if update_version {
+                // Read the current CFPA areas to figure out what version we
+                // need to set.
+                let ping = do_isp_read_memory(&mut *port, 0x9_e000, 512)?;
+                let pong = do_isp_read_memory(&mut *port, 0x9_e200, 512)?;
+
+                let ping = lpc55_areas::CFPAPage::from_bytes(ping[..].try_into().unwrap())?;
+                let pong = lpc55_areas::CFPAPage::from_bytes(pong[..].try_into().unwrap())?;
+
+                println!(
+                    "ping sector v={}, pong sector v={}",
+                    ping.version, pong.version
+                );
+                let start_version = u32::max(ping.version, pong.version);
+                if new_cfpa.version != start_version {
+                    new_cfpa.version = start_version;
+                }
+                new_cfpa.update_version();
+                println!("note: updated version is {}", new_cfpa.version);
+            }
+
+            let new_bytes = new_cfpa.to_vec()?;
+            do_isp_write_memory(&mut *port, 0x9_de00, new_bytes)?;
+            println!("Write to CFPA done!");
         }
         ISPCommand::Restore => {
             do_ping(&mut *port)?;

--- a/lpc55_isp/src/bin/lpc55_flash.rs
+++ b/lpc55_isp/src/bin/lpc55_flash.rs
@@ -397,10 +397,7 @@ fn main() -> Result<()> {
                     ping.version, pong.version
                 );
                 let start_version = u32::max(ping.version, pong.version);
-                if new_cfpa.version != start_version {
-                    new_cfpa.version = start_version;
-                }
-                new_cfpa.update_version();
+                new_cfpa.version = start_version + 1;
                 println!("note: updated version is {}", new_cfpa.version);
             }
 

--- a/lpc55_isp/src/cmd.rs
+++ b/lpc55_isp/src/cmd.rs
@@ -238,6 +238,29 @@ pub fn do_isp_flash_erase_all(port: &mut dyn serialport::SerialPort) -> Result<(
     Ok(())
 }
 
+pub fn do_isp_flash_erase_region(
+    port: &mut dyn serialport::SerialPort,
+    start_address: u32,
+    byte_count: u32,
+) -> Result<()> {
+    let args = vec![
+        start_address,
+        byte_count,
+        // Erase internal flash
+        0x0_u32,
+    ];
+
+    do_command(
+        port,
+        CommandTag::FlashEraseRegion,
+        ResponseCode::Generic,
+        args,
+        DataPhase::NoData,
+    )?;
+
+    Ok(())
+}
+
 pub fn do_isp_get_property(
     port: &mut dyn serialport::SerialPort,
     prop: BootloaderProperty,

--- a/lpc55_isp/src/isp.rs
+++ b/lpc55_isp/src/isp.rs
@@ -62,6 +62,7 @@ pub enum KeyProvisionCmds {
 #[derive(Debug)]
 pub enum CommandTag {
     FlashEraseAll = 0x1,
+    FlashEraseRegion = 0x2,
     ReadMemory = 0x3,
     WriteMemory = 0x4,
     GetProperty = 0x7,
@@ -575,6 +576,24 @@ pub fn do_isp_flash_erase_all(port: &mut dyn serialport::SerialPort) -> Result<(
     ];
 
     send_command(port, CommandTag::FlashEraseAll, args)?;
+
+    read_response(port, ResponseCode::Generic)?;
+
+    Ok(())
+}
+
+pub fn do_isp_flash_erase_region(
+    port: &mut dyn serialport::SerialPort,
+    start_address: u32,
+    byte_count: u32,
+) -> Result<()> {
+    let args = vec![
+        start_address,
+        byte_count,
+        0_u32, // internal flash memory identifier
+    ];
+
+    send_command(port, CommandTag::FlashEraseRegion, args)?;
 
     read_response(port, ResponseCode::Generic)?;
 

--- a/lpc55_sign/Cargo.toml
+++ b/lpc55_sign/Cargo.toml
@@ -22,6 +22,7 @@ rsa = "0.6.1"
 lpc55_areas = { path = "../lpc55_areas", features = [] }
 serde = { version = "1", features = ["derive"] }
 toml = "0.5.6"
+parse_int = "0.6.0"
 
 [features]
 default = ["binaries"]

--- a/lpc55_sign/src/bin/lpc55_sign.rs
+++ b/lpc55_sign/src/bin/lpc55_sign.rs
@@ -157,7 +157,7 @@ fn main() -> Result<()> {
             );
             if let Some(cfpa_path) = cfpa {
                 let mut cfpa = CFPAPage::default();
-                cfpa.update_version();
+                cfpa.version += 1; // allow overwrite of default 0
 
                 let mut rkth = RKTHRevoke::new();
                 rkth.rotk0 = ROTKeyStatus::enabled().into();

--- a/lpc55_sign/src/crc_image.rs
+++ b/lpc55_sign/src/crc_image.rs
@@ -9,7 +9,7 @@ use lpc55_areas::{BootField, BootImageType};
 use packed_struct::prelude::*;
 use std::path::Path;
 
-pub fn update_crc(src: &Path, dest: &Path) -> Result<()> {
+pub fn update_crc(src: &Path, dest: &Path, address: u32) -> Result<()> {
     let mut bytes = std::fs::read(src)?;
 
     // We need to update 3 fields before calculating the CRC:
@@ -30,8 +30,7 @@ pub fn update_crc(src: &Path, dest: &Path) -> Result<()> {
     let boot_field = BootField::new(BootImageType::CRCImage);
     bytes[0x24..0x28].clone_from_slice(&boot_field.pack()?);
 
-    // Our execution address is always 0
-    byteorder::LittleEndian::write_u32(&mut bytes[0x34..0x38], 0x0);
+    byteorder::LittleEndian::write_u32(&mut bytes[0x34..0x38], address);
 
     // The CRC algorithm NXP uses is crc32 / MPEG-2
     // poly: 0x04c11db7

--- a/lpc55_sign/src/sign_ecc.rs
+++ b/lpc55_sign/src/sign_ecc.rs
@@ -36,7 +36,12 @@ fn get_pad(val: usize) -> usize {
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-fn do_ecc_sign_image(binary_path: &Path, priv_key_path: &Path, outfile_path: &Path) -> Result<()> {
+fn do_ecc_sign_image(
+    binary_path: &Path,
+    priv_key_path: &Path,
+    outfile_path: &Path,
+    address: u32,
+) -> Result<()> {
     let mut bytes = std::fs::read(binary_path)?;
     let image_pad = get_pad(bytes.len());
 
@@ -92,8 +97,8 @@ fn do_ecc_sign_image(binary_path: &Path, priv_key_path: &Path, outfile_path: &Pa
     let boot_field = BootField::new(BootImageType::SignedImage);
 
     bytes[0x24..0x28].clone_from_slice(&boot_field.pack()?);
-    // Our execution address is always 0
-    byteorder::LittleEndian::write_u32(&mut bytes[0x34..0x38], 0x0);
+    // Our execution address is next
+    byteorder::LittleEndian::write_u32(&mut bytes[0x34..0x38], address);
     // where to find the block. For now just stick it right after the image
     byteorder::LittleEndian::write_u32(&mut bytes[0x28..0x2c], (image_len + image_pad) as u32);
 
@@ -141,6 +146,11 @@ fn do_ecc_sign_image(binary_path: &Path, priv_key_path: &Path, outfile_path: &Pa
     Ok(())
 }
 
-pub fn ecc_sign_image(src_bin: &Path, priv_key: &Path, dest_bin: &Path) -> Result<()> {
-    do_ecc_sign_image(src_bin, priv_key, dest_bin)
+pub fn ecc_sign_image(
+    src_bin: &Path,
+    priv_key: &Path,
+    dest_bin: &Path,
+    address: u32,
+) -> Result<()> {
+    do_ecc_sign_image(src_bin, priv_key, dest_bin, address)
 }

--- a/lpc55_sign/src/signed_image.rs
+++ b/lpc55_sign/src/signed_image.rs
@@ -58,6 +58,7 @@ pub fn sign_chain(
     cert_path_prefix: Option<&Path>,
     certs: &[CertChain],
     outfile_path: &Path,
+    execution_address: u32,
 ) -> Result<[u8; 32]> {
     validate_certs(certs)?;
 
@@ -152,8 +153,8 @@ pub fn sign_chain(
     let boot_field = BootField::new(BootImageType::SignedImage);
 
     bytes[0x24..0x28].clone_from_slice(&boot_field.pack()?);
-    // Our execution address is always 0
-    byteorder::LittleEndian::write_u32(&mut bytes[0x34..0x38], 0x0);
+    // Our execution address goes in the next word
+    byteorder::LittleEndian::write_u32(&mut bytes[0x34..0x38], execution_address);
     // where to find the block. For now just stick it right after the image
     byteorder::LittleEndian::write_u32(&mut bytes[0x28..0x2c], (image_len + image_pad) as u32);
 
@@ -222,6 +223,7 @@ pub fn sign_image(
     priv_key_path: &Path,
     root_cert0_path: &Path,
     outfile_path: &Path,
+    execution_address: u32,
 ) -> Result<[u8; 32]> {
     let mut bytes = std::fs::read(binary_path)?;
     let image_pad = get_pad(bytes.len());
@@ -283,8 +285,8 @@ pub fn sign_image(
     let boot_field = BootField::new(BootImageType::SignedImage);
 
     bytes[0x24..0x28].clone_from_slice(&boot_field.pack()?);
-    // Our execution address is always 0
-    byteorder::LittleEndian::write_u32(&mut bytes[0x34..0x38], 0x0);
+    // Our execution address goes in the next word
+    byteorder::LittleEndian::write_u32(&mut bytes[0x34..0x38], execution_address);
     // where to find the block. For now just stick it right after the image
     byteorder::LittleEndian::write_u32(&mut bytes[0x28..0x2c], (image_len + image_pad) as u32);
 


### PR DESCRIPTION
- Tools that insert image headers (crc, sign) now take a command line flag for inserting the intended image execution address. (alt-stage0 no longer requires this but I figured the code was useful to upstream anyway.)
- You can now erase a region of flash without affecting adjacent sectors.
- It is now possible to program the CFPA; the signing tools will optionally generate a CFPA image if given the `--cfpa PATH` switch.