### PR TITLE
Refactor image signing routines

### DIFF
--- a/lpc55_sign/src/signed_image.rs
+++ b/lpc55_sign/src/signed_image.rs
@@ -2,20 +2,18 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use anyhow::{anyhow, Context, Result};
-use byteorder::{ByteOrder, WriteBytesExt};
+use std::convert::TryInto;
+
+use anyhow::{anyhow, Result};
+use byteorder::{ByteOrder, LittleEndian};
 use lpc55_areas::*;
+use packed_struct::prelude::*;
 use rsa::{
     pkcs1::DecodeRsaPrivateKey, pkcs1::DecodeRsaPublicKey, pkcs8::DecodePrivateKey, PublicKeyParts,
+    RsaPrivateKey, RsaPublicKey,
 };
-use sha2::Digest;
-
-use packed_struct::prelude::*;
-use serde::Deserialize;
-use std::convert::TryInto;
-use std::fs::OpenOptions;
-use std::io::Write;
-use std::path::{Path, PathBuf};
+use sha2::{Digest, Sha256};
+use x509_parser::parse_x509_certificate;
 
 fn get_pad(val: usize) -> usize {
     match val.checked_rem(4) {
@@ -24,333 +22,115 @@ fn get_pad(val: usize) -> usize {
     }
 }
 
-#[derive(Clone, Debug, Deserialize)]
-#[serde(rename_all = "kebab-case", deny_unknown_fields)]
-pub struct CertChain {
-    pub cert_paths: Vec<PathBuf>,
-    pub priv_key: Option<PathBuf>,
-}
-
-#[derive(Clone, Debug, Deserialize)]
-#[serde(rename_all = "kebab-case", deny_unknown_fields)]
-pub struct CfgFile {
-    pub certs: Vec<CertChain>,
-}
-
-fn validate_certs(certs: &[CertChain]) -> Result<()> {
-    if certs.len() > 4 {
-        return Err(anyhow!("Too many certificate chains, max is 4"));
-    }
-
-    let cnt = certs.iter().filter(|c| c.priv_key.is_some()).count();
-
-    if cnt != 1 {
-        return Err(anyhow!(
-            "Exactly one certificate chain should specify a private key for signing"
-        ));
-    }
-
-    Ok(())
-}
-
-pub fn sign_chain(
-    binary_path: &Path,
-    cert_path_prefix: Option<&Path>,
-    certs: &[CertChain],
-    outfile_path: &Path,
+/// Prepare an image for signing: append a certificate table,
+/// write the augmented length into the header, and compute &
+/// append the root-key-hash table. Returns the stamped image
+/// and the root-key-table hash.
+pub fn stamp_image(
+    binary: &[u8],
+    signing_certs: &[&[u8]],
+    root_certs: &[&[u8]; 4],
     execution_address: u32,
-) -> Result<[u8; 32]> {
-    validate_certs(certs)?;
-
-    let prefix = if let Some(p) = cert_path_prefix {
-        p
-    } else {
-        Path::new(".")
-    };
-
-    let mut bytes = std::fs::read(binary_path)?;
-    let image_pad = get_pad(bytes.len());
-
-    let signing_chain = certs.iter().find(|c| c.priv_key.is_some()).unwrap();
-
-    // Generate the byte sequence for the signing certificates. This includes
-    // adding the (padded) length of each certificate.
-    let signing_certs: Vec<u8> = signing_chain
-        .cert_paths
+) -> Result<(Vec<u8>, [u8; 32])> {
+    if signing_certs.len() < 1 {
+        return Err(anyhow!("Need at least a root certificate"));
+    }
+    if root_certs
         .iter()
-        .flat_map(|path| {
-            let full_path = prefix.join(path);
-            let cert_bytes = std::fs::read(&full_path)
-                .with_context(|| format!("could not load cert at {full_path:?}"))
-                .unwrap();
-            let cert_pad = get_pad(cert_bytes.len());
-            let padded_len = cert_bytes.len() + cert_pad;
-            let mut v = Vec::new();
+        .find(|&&cert| cert == signing_certs[0])
+        .is_none()
+    {
+        return Err(anyhow!("Root signing certificate must appear in root list"));
+    }
 
-            v.extend_from_slice(&(padded_len as u32).to_le_bytes());
-            v.extend_from_slice(&cert_bytes);
-            if cert_pad > 0 {
-                v.extend_from_slice(&vec![0; cert_pad]);
-            }
+    let mut image_bytes = binary.to_owned();
+    let image_len = image_bytes.len();
+    let image_pad = get_pad(image_len);
 
-            v
-        })
-        .collect();
+    // Generate the certificate table, including the padded length
+    // of each certificate.
+    let mut cert_table = Vec::new();
+    for cert in signing_certs {
+        let cert_pad = get_pad(cert.len());
+        let padded_len = cert.len() + cert_pad;
+        cert_table.extend_from_slice(&(padded_len as u32).to_le_bytes());
+        cert_table.extend_from_slice(cert);
+        if cert_pad > 0 {
+            cert_table.extend_from_slice(&vec![0; cert_pad]);
+        }
+    }
+    let cert_table_len = cert_table.len();
+    let cert_header_len = CertHeader::packed_bytes_size(None)?;
+    let mut cert_header: CertHeader = CertHeader::new(cert_header_len, cert_table_len);
+    cert_header.certificate_count = signing_certs.len() as u32;
+    let cert_table_len = cert_header.certificate_table_len as usize;
 
-    let cert_len = signing_certs.len();
+    // How many bytes we sign, including image, cert table, and root key hashes.
+    let signed_len = image_len + image_pad + cert_header_len + cert_table_len + 4 * 32;
+    cert_header.total_image_len = signed_len.try_into()?;
 
-    let root_cnt = certs.len();
+    // Start writing the image header.
+    // Total image length includes XXX bytes of signature.
+    let total_len = signed_len + 256; // TODO: 256 only correct for 2048-bit keys
+    LittleEndian::write_u32(&mut image_bytes[0x20..0x24], total_len as u32);
 
-    // SHA of each Root Key. This needs to go into each image and _must_
-    // match the SHA programmed in the CMPA area!
-    let root_hashes = certs.iter().map(|c| {
-        let root_bytes = std::fs::read(prefix.join(&c.cert_paths[0])).unwrap();
-        let (_, root0) = x509_parser::parse_x509_certificate(&root_bytes).unwrap();
-        let root0_pubkey =
-            rsa::RsaPublicKey::from_pkcs1_der(root0.public_key().subject_public_key.as_ref())
-                .unwrap();
-
-        // We need the sha256 of the pubkeys. This is just the sha256
-        // of n + e from the pubkey
-        let n = root0_pubkey.n();
-        let e = root0_pubkey.e();
-
-        let mut sha = sha2::Sha256::new();
-        sha.update(&n.to_bytes_be());
-        sha.update(&e.to_bytes_be());
-        let result = sha.finalize();
-        let mut v: Vec<u8> = vec![0; 32];
-        v.copy_from_slice(&result);
-        v
-    });
-
-    // We're relying on packed_struct to catch errors of padding
-    // or size since we know how big this should be
-    let cert_header_size = CertHeader::packed_bytes_size(None)?;
-
-    let mut new_cert_header: CertHeader = CertHeader::new(cert_header_size, cert_len);
-
-    new_cert_header.certificate_count = signing_chain.cert_paths.len() as u32;
-
-    // some math on how many bytes we sign
-    //
-    // Base image + padding
-    // certificate header block
-    // certificate length
-    // 4 sha256 hashes
-    let signed_len = bytes.len()
-        + image_pad
-        + cert_header_size
-        + (new_cert_header.certificate_table_len as usize)
-        + 32 * 4;
-
-    // Total image length includes 256 bytes of signature
-    let total_len = signed_len + 256;
-
-    new_cert_header.total_image_len = signed_len.try_into().unwrap();
-
-    let image_len = bytes.len();
-
-    byteorder::LittleEndian::write_u32(&mut bytes[0x20..0x24], total_len as u32);
-
+    // Next comes the boot field.
     let boot_field = BootField::new(BootImageType::SignedImage);
+    image_bytes[0x24..0x28].clone_from_slice(&boot_field.pack()?);
 
-    bytes[0x24..0x28].clone_from_slice(&boot_field.pack()?);
-    // Our execution address goes in the next word
-    byteorder::LittleEndian::write_u32(&mut bytes[0x34..0x38], execution_address);
-    // where to find the block. For now just stick it right after the image
-    byteorder::LittleEndian::write_u32(&mut bytes[0x28..0x2c], (image_len + image_pad) as u32);
+    // Then the location of the certificate table: right after the image.
+    LittleEndian::write_u32(&mut image_bytes[0x28..0x2c], (image_len + image_pad) as u32);
 
-    let mut out = OpenOptions::new()
-        .write(true)
-        .truncate(true)
-        .append(false)
-        .create(true)
-        .open(outfile_path)?;
+    // Optionally write the image execution address.
+    if execution_address > 0 {
+        LittleEndian::write_u32(&mut image_bytes[0x34..0x38], execution_address);
+    }
 
-    // Generate the image, see 7.3.4 of v2.4 UM 11126 for the layout
-    out.write_all(&bytes)?;
+    // Generate the image, see 7.3.4 of v2.4 UM 11126 for the layout.
     if image_pad > 0 {
-        out.write_all(&vec![0; image_pad])?;
+        image_bytes.extend_from_slice(&vec![0; image_pad])
     }
-    out.write_all(&new_cert_header.pack()?)?;
-    out.write_all(&signing_certs)?;
-    let mut rkth_sha = sha2::Sha256::new();
-    for c in root_hashes {
-        out.write_all(&c)?;
-        rkth_sha.update(&c);
+    image_bytes.extend_from_slice(&cert_header.pack()?);
+    image_bytes.extend_from_slice(&cert_table);
+
+    // The hash of each root public key (i.e., of its raw `n` and `e` values)
+    // goes into the image and _must_ match the hash-of-hashes programmed in
+    // the CMPA!
+    let mut rkth = Sha256::new();
+    for root in root_certs {
+        let root_key_hash: [u8; 32] = if root.is_empty() {
+            [0; 32]
+        } else {
+            let (_, root_cert) = parse_x509_certificate(root)?;
+            let root_key = root_cert.public_key().subject_public_key.as_ref();
+            let root_key = RsaPublicKey::from_pkcs1_der(root_key)?;
+            let mut hash = Sha256::new();
+            hash.update(&root_key.n().to_bytes_be());
+            hash.update(&root_key.e().to_bytes_be());
+            hash.finalize().as_slice().try_into()?
+        };
+        image_bytes.extend_from_slice(&root_key_hash);
+        rkth.update(&root_key_hash);
     }
-    for _ in 0..(4 - root_cnt) {
-        let empty_hash: [u8; 32] = [0; 32];
-        out.write_all(&empty_hash)?;
-        rkth_sha.update(empty_hash);
-    }
-
-    drop(out);
-
-    // the easiest way to get the bytes we need to sign is to read back
-    // what we just wrote
-    let sign_bytes = std::fs::read(outfile_path)?;
-
-    let mut img_hash = sha2::Sha256::new();
-    img_hash.update(&sign_bytes);
-
-    let priv_key_path = signing_chain.priv_key.as_ref().unwrap();
-    let priv_key = rsa::RsaPrivateKey::read_pkcs1_pem_file(prefix.join(priv_key_path))
-        .or_else(|_| rsa::RsaPrivateKey::read_pkcs8_pem_file(prefix.join(priv_key_path)))?;
-
-    let sig = priv_key.sign(
-        rsa::pkcs1v15::Pkcs1v15Sign::new::<rsa::sha2::Sha256>(),
-        img_hash.finalize().as_slice(),
-    )?;
-
-    println!("Image signature {:x?}", sig);
-
-    let mut out = OpenOptions::new()
-        .write(true)
-        .append(true)
-        .open(outfile_path)?;
-
-    out.write_all(sig.as_ref())?;
-    drop(out);
-
-    // TODO check the signature with the public key
-    let rkth = rkth_sha.finalize();
-    Ok(rkth.as_slice().try_into().expect("something went wrong?"))
+    Ok((image_bytes, rkth.finalize().as_slice().try_into()?))
 }
 
-pub fn sign_image(
-    binary_path: &Path,
-    priv_key_path: &Path,
-    root_cert0_path: &Path,
-    outfile_path: &Path,
-    execution_address: u32,
-) -> Result<[u8; 32]> {
-    let mut bytes = std::fs::read(binary_path)?;
-    let image_pad = get_pad(bytes.len());
+/// Decode the private key, sign the stamped image with it,
+/// and append the signature to the image.
+pub fn sign_image(binary: &[u8], private_key: &str) -> Result<Vec<u8>> {
+    let mut image_hash = Sha256::new();
+    image_hash.update(binary);
 
-    let priv_key = rsa::RsaPrivateKey::read_pkcs1_pem_file(priv_key_path)
-        .or_else(|_| rsa::RsaPrivateKey::read_pkcs8_pem_file(priv_key_path))?;
-
-    let root0_bytes = std::fs::read(root_cert0_path)?;
-    let cert_pad = get_pad(root0_bytes.len());
-
-    // We're relying on packed_struct to catch errors of padding
-    // or size since we know how big this should be
-    let cert_header_size = CertHeader::packed_bytes_size(None)?;
-
-    let mut new_cert_header: CertHeader = CertHeader::new(
-        cert_header_size,
-        // This is the total length of all certificates (plus padding)
-        // Plus 4 bytes to store the x509 certificate length
-        root0_bytes.len() + 4 + cert_pad,
-    );
-
-    // some math on how many bytes we sign
-    //
-    // Base image + padding
-    // certificate header block
-    // 4 bytes for certificate length
-    // certificate itself plus padding
-    // 4 sha256 hashes
-    let signed_len = bytes.len()
-        + image_pad
-        + cert_header_size
-        + (new_cert_header.certificate_table_len as usize)
-        + 32 * 4;
-
-    // Total image length includes 256 bytes of signature
-    let total_len = signed_len + 256;
-
-    new_cert_header.total_image_len = signed_len.try_into().unwrap();
-
-    let (_, root0) = x509_parser::parse_x509_certificate(&root0_bytes)?;
-
-    let root0_pubkey =
-        rsa::RsaPublicKey::from_pkcs1_der(root0.public_key().subject_public_key.as_ref())?;
-
-    // We need the sha256 of the pubkeys. This is just the sha256
-    // of n + e from the pubkey
-    let n = root0_pubkey.n();
-    let e = root0_pubkey.e();
-
-    let mut sha = sha2::Sha256::new();
-    sha.update(&n.to_bytes_be());
-    sha.update(&e.to_bytes_be());
-    let root0_sha = sha.finalize();
-
-    let image_len = bytes.len();
-
-    byteorder::LittleEndian::write_u32(&mut bytes[0x20..0x24], total_len as u32);
-
-    let boot_field = BootField::new(BootImageType::SignedImage);
-
-    bytes[0x24..0x28].clone_from_slice(&boot_field.pack()?);
-    // Our execution address goes in the next word
-    byteorder::LittleEndian::write_u32(&mut bytes[0x34..0x38], execution_address);
-    // where to find the block. For now just stick it right after the image
-    byteorder::LittleEndian::write_u32(&mut bytes[0x28..0x2c], (image_len + image_pad) as u32);
-
-    let mut out = OpenOptions::new()
-        .write(true)
-        .truncate(true)
-        .append(false)
-        .create(true)
-        .open(outfile_path)?;
-
-    // Need to write out an empty sha since we only have one root key
-    let empty_hash: [u8; 32] = [0; 32];
-
-    out.write_all(&bytes)?;
-    if image_pad > 0 {
-        out.write_all(&vec![0; image_pad])?;
-    }
-    out.write_all(&new_cert_header.pack()?)?;
-    out.write_u32::<byteorder::LittleEndian>((root0_bytes.len() + cert_pad) as u32)?;
-    out.write_all(&root0_bytes)?;
-    if cert_pad > 0 {
-        out.write_all(&vec![0; cert_pad])?;
-    }
-    // We may eventually have more hashes
-    out.write_all(&root0_sha)?;
-    out.write_all(&empty_hash)?;
-    out.write_all(&empty_hash)?;
-    out.write_all(&empty_hash)?;
-
-    // The sha256 of all the root keys gets put in in the CMPA area
-    let mut rkth_sha = sha2::Sha256::new();
-    rkth_sha.update(root0_sha);
-    rkth_sha.update(empty_hash);
-    rkth_sha.update(empty_hash);
-    rkth_sha.update(empty_hash);
-
-    let rkth = rkth_sha.finalize();
-
-    drop(out);
-
-    // the easiest way to get the bytes we need to sign is to read back
-    // what we just wrote
-    let sign_bytes = std::fs::read(outfile_path)?;
-
-    let mut img_hash = sha2::Sha256::new();
-    img_hash.update(&sign_bytes);
-
-    let sig = priv_key.sign(
+    let private_key = RsaPrivateKey::from_pkcs1_pem(private_key)
+        .or_else(|_| RsaPrivateKey::from_pkcs8_pem(private_key))?;
+    let signature = private_key.sign(
         rsa::pkcs1v15::Pkcs1v15Sign::new::<rsa::sha2::Sha256>(),
-        img_hash.finalize().as_slice(),
+        image_hash.finalize().as_slice(),
     )?;
 
-    println!("Image signature {:x?}", sig);
-
-    let mut out = OpenOptions::new()
-        .write(true)
-        .append(true)
-        .open(outfile_path)?;
-
-    out.write_all(sig.as_ref())?;
-    drop(out);
-
-    Ok(rkth.as_slice().try_into().expect("something went wrong?"))
+    let mut signed = binary.to_owned();
+    signed.extend_from_slice(&signature);
+    Ok(signed)
 }
 
 pub fn create_cmpa(
@@ -359,16 +139,8 @@ pub fn create_cmpa(
     with_dice_cust_cfg: bool,
     with_dice_inc_sec_epoch: bool,
     rkth: &[u8; 32],
-    cmpa_path: &Path,
-) -> Result<()> {
-    let mut cmpa_out = OpenOptions::new()
-        .write(true)
-        .truncate(true)
-        .create(true)
-        .open(cmpa_path)?;
-
+) -> Result<Vec<u8>> {
     let mut secure_boot_cfg = SecureBootCfg::new();
-
     secure_boot_cfg.set_dice(with_dice);
     secure_boot_cfg.set_dice_inc_nxp_cfg(with_dice_inc_nxp_cfg);
     secure_boot_cfg.set_dice_inc_cust_cfg(with_dice_cust_cfg);
@@ -376,14 +148,10 @@ pub fn create_cmpa(
     secure_boot_cfg.set_sec_boot(true);
 
     let mut cmpa = CMPAPage::new();
-
     cmpa.set_secure_boot_cfg(secure_boot_cfg)?;
     cmpa.set_rotkh(rkth);
-
     cmpa.set_debug_fields(DebugSettings::new())?;
     cmpa.set_boot_cfg(DefaultIsp::Auto, BootSpeed::Fro96mhz)?;
-    let cmpa_bytes = cmpa.pack()?;
 
-    cmpa_out.write_all(&cmpa_bytes)?;
-    Ok(())
+    Ok(cmpa.pack()?.try_into()?)
 }


### PR DESCRIPTION
The image signing routines in `lpc55_sign::signed_images` did too much at once to be usable by a service like permission-slip: they read images from files, prepared them for signing ("stamping"), performed the cryptographic signing using an explicit private key (ok for testing, not for prod!), and wrote the signed images to files.

We now handle each of those operations separately, and the routines in the `signed_image` module now operate entirely with in-memory binaries and certificates. We also combine what was previously `sign_chain`  and `sign_image` into a single stamping routine that always expects a signing cert chain (which may be just a root) and four root certs (one of which must be the root of the signing chain). Please let me know if you think this design is more or less confusing than the old one.

The certificate chain configuration file and other file I/O have been moved into the caller (`lpc55_sign::main` and `write_signed_image`) and completely revamped & refactored. It's possible I cut too deep here, but the previous representation (four chains, only one of which could have a private key and length > 1) seemed confusing. Please let me know if you strongly preferred or depend on the old configuration.

The *draft* status may be removed once the cert chain configuration has been tested/vetted.