### PR TITLE
Switch to workspace deps; bump clap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,47 +151,17 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b63edc3f163b3c71ec8aa23f9bd6070f77edbf3d1d198b164afa90ff00e4ec62"
-dependencies = [
- "atty",
- "bitflags",
- "clap_derive 3.0.14",
- "indexmap",
- "lazy_static",
- "os_str_bytes",
- "strsim",
- "termcolor",
- "textwrap",
-]
-
-[[package]]
-name = "clap"
 version = "4.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d7ae14b20b94cb02149ed21a86c423859cbe18dc7ed69845cace50e52b40a5"
 dependencies = [
  "bitflags",
- "clap_derive 4.1.8",
+ "clap_derive",
  "clap_lex",
  "is-terminal",
  "once_cell",
  "strsim",
  "termcolor",
-]
-
-[[package]]
-name = "clap_derive"
-version = "3.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a1132dc3944b31c20dd8b906b3a9f0a5d0243e092d59171414969657ac6aa85"
-dependencies = [
- "heck 0.4.0",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -247,9 +217,6 @@ name = "crc-any"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "073375684a58dece169afbdc9879a027f3698118ad3814938316c6002b7aa921"
-dependencies = [
- "debug-helper",
-]
 
 [[package]]
 name = "crypto-bigint"
@@ -278,12 +245,6 @@ name = "data-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
-
-[[package]]
-name = "debug-helper"
-version = "0.3.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76fbd10dce159c002b9c688ae8ab7cd531151e185e0ad360f4bfea3b0eede3a8"
 
 [[package]]
 name = "der"
@@ -432,9 +393,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.3"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
  "libc",
@@ -451,12 +412,6 @@ dependencies = [
  "rand_core",
  "subtle",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
 name = "heck"
@@ -501,16 +456,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.6",
-]
-
-[[package]]
-name = "indexmap"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
-dependencies = [
- "autocfg",
- "hashbrown",
 ]
 
 [[package]]
@@ -566,26 +511,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
 
 [[package]]
-name = "libudev"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b324152da65df7bb95acfcaab55e3097ceaab02fb19b228a9eb74d55f135e0"
-dependencies = [
- "libc",
- "libudev-sys",
-]
-
-[[package]]
-name = "libudev-sys"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c8469b4a23b962c1396b9b451dda50ef5b283e8dd309d69033475fa9b334324"
-dependencies = [
- "libc",
- "pkg-config",
-]
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -622,7 +547,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "byteorder",
- "clap 3.0.14",
+ "clap",
  "crc-any",
  "hex",
  "lpc55_areas",
@@ -643,7 +568,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "byteorder",
- "clap 4.1.8",
+ "clap",
  "colored",
  "crc-any",
  "ecdsa",
@@ -809,9 +734,6 @@ name = "os_str_bytes"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "p256"
@@ -896,12 +818,6 @@ dependencies = [
  "der 0.7.1",
  "spki 0.7.0",
 ]
-
-[[package]]
-name = "pkg-config"
-version = "0.3.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12295df4f294471248581bc09bef3c38a5e46f1e36d6a37353621a0c6c357e1f"
 
 [[package]]
 name = "ppv-lite86"
@@ -1100,7 +1016,6 @@ dependencies = [
  "base16ct",
  "der 0.7.1",
  "generic-array",
- "pkcs8 0.10.1",
  "subtle",
  "zeroize",
 ]
@@ -1135,7 +1050,6 @@ dependencies = [
  "IOKit-sys",
  "bitflags",
  "cfg-if",
- "libudev",
  "mach 0.3.2",
  "nix",
  "regex",
@@ -1204,7 +1118,6 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0445c905640145c7ea8c1993555957f65e7c46d0535b91ba501bc9bfc85522f"
 dependencies = [
- "base64ct",
  "der 0.7.1",
 ]
 
@@ -1257,18 +1170,12 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "termcolor"
-version = "1.1.2"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
 ]
-
-[[package]]
-name = "textwrap"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
 
 [[package]]
 name = "thiserror"
@@ -1337,9 +1244,9 @@ checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
+version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
@@ -1447,9 +1354,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
@@ -1462,45 +1369,45 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "wyz"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,36 @@
-cargo-features = ["resolver"]
+cargo-features = ["resolver", "named-profiles"]
 
 [workspace]
 members = [
-	"lpc55_areas",
-	"lpc55_sign",
-	"lpc55_isp",
+    "lpc55_areas",
+    "lpc55_sign",
+    "lpc55_isp",
 ]
+resolver = "2"
+
+[workspace.dependencies]
+anyhow = { version = "1", default-features = false, features = ["std"] }
+bitfield = { version = "0.14.0", default-features = false }
+byteorder = { version = "1.3.4", default-features = false, features = ["std"] }
+clap = { version = "4", default-features = false, features = ["std", "derive", "default"] }
+colored = { version = "2.0", default-features = false }
+crc-any = { version = "2.3.5", default-features = false }
+ecdsa = { version = "0.16.0", default-features = false, features = ["pkcs8", "der"] }
+elliptic-curve = { version = "0.13.1", default-features = false }
+hex = { version = "0.4.3", default-features = false, features = ["std"] }
+num-derive = { version = "0.3.0", default-features = false, features = ["full-syntax"] }
+num-traits = { version = "0.2.14", default-features = false }
+p256 = { version = "0.13.0", default-features = false, features = ["ecdsa", "pkcs8"] }
+packed_struct = { version = "0.10.0", default-features = false, features = ["std"] }
+packed_struct_codegen = { version = "0.10.0", default-features = false, features = ["std"] }
+parse_int = { version = "0.6.0", default-features = false }
+rsa = { version = "0.8.1", default-features = false, features = ["std", "pem", "sha2"] }
+serde = { version = "1", default-features = false, features = ["derive"] }
+serialport = { version = "4.2.0", default-features = false }
+sha2 = { version = "0.9.8", default-features = false }
+strum = { version = "0.22", default-features = false, features = ["std"] }
+strum_macros = { version = "0.22", default-features = false }
+toml = { version = "0.5.6", default-features = false }
+x509-parser = { version = "0.12.0", default-features = false, features = ["verify"] }
+
+lpc55_areas = { path = "lpc55_areas", default-features = false }

--- a/lpc55_areas/Cargo.toml
+++ b/lpc55_areas/Cargo.toml
@@ -6,16 +6,16 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-packed_struct = "0.10.0"
-packed_struct_codegen = "0.10.0"
-anyhow = "1.0.32"
-byteorder = "1.3.4"
-hex = "0.4.3"
-parse_int = "0.6.0"
-num-derive = { version = "0.3.0", features = [ "full-syntax" ] }
-num-traits = "0.2.14"
-bitfield = "0.14.0"
-serde = { version = "1.0.114", features = ["derive"] }
+anyhow.workspace = true
+bitfield.workspace = true
+byteorder.workspace = true
+hex.workspace = true
+num-derive.workspace = true
+num-traits.workspace = true
+packed_struct.workspace = true
+packed_struct_codegen.workspace = true
+parse_int.workspace = true
+serde.workspace = true
 
 [features]
 default = ["binaries"]

--- a/lpc55_isp/Cargo.toml
+++ b/lpc55_isp/Cargo.toml
@@ -6,21 +6,21 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-packed_struct = "0.10.0"
-packed_struct_codegen = "0.10.0"
-anyhow = "1.0.32"
-serialport = "4.2.0"
-crc-any = "2.3.5"
-byteorder = "1.3.4"
-clap = { version = "3.0.14", features = ["derive"] }
-hex = "0.4.3"
-parse_int = "0.6.0"
-lpc55_areas = { path = "../lpc55_areas", features = [] }
-sha2 = "0.9.8"
-num-derive = { version = "0.3.0", features = [ "full-syntax" ] }
-num-traits = "0.2.14"
-strum = "0.22"
-strum_macros = "0.22"
+anyhow.workspace = true
+byteorder.workspace = true
+clap.workspace = true
+crc-any.workspace = true
+hex.workspace = true
+lpc55_areas.workspace = true
+num-derive.workspace = true
+num-traits.workspace = true
+packed_struct.workspace = true
+packed_struct_codegen.workspace = true
+parse_int.workspace = true
+serialport.workspace = true
+sha2.workspace = true
+strum.workspace = true
+strum_macros.workspace = true
 
 [features]
 default = ["binaries"]

--- a/lpc55_isp/src/bin/cfpa-update.rs
+++ b/lpc55_isp/src/bin/cfpa-update.rs
@@ -20,7 +20,7 @@ struct Args {
     #[clap(name = "port")]
     isp_port: String,
     /// Optional out file for the CFPA region
-    #[clap(name = "outfile", parse(from_os_str))]
+    #[clap(name = "outfile")]
     outfile: Option<PathBuf>,
 }
 

--- a/lpc55_isp/src/bin/lpc55_flash.rs
+++ b/lpc55_isp/src/bin/lpc55_flash.rs
@@ -10,6 +10,7 @@ use lpc55_isp::isp::{do_ping, BootloaderProperty, KeyType};
 use serialport::{DataBits, FlowControl, Parity, StopBits};
 use std::io::{Read, Write};
 use std::path::PathBuf;
+use std::str::FromStr;
 use std::time::Duration;
 
 #[derive(Debug, Parser)]
@@ -20,19 +21,17 @@ enum ISPCommand {
     /// Reads memory from the specified address and saves it at the path
     #[clap(name = "read-memory")]
     ReadMemory {
-        #[clap(parse(try_from_str = parse_int::parse))]
+        #[arg(value_parser = parse_int::parse::<u32>)]
         address: u32,
-        #[clap(parse(try_from_str = parse_int::parse))]
+        #[arg(value_parser = parse_int::parse::<u32>)]
         count: u32,
-        #[clap(parse(from_os_str))]
         path: PathBuf,
     },
     /// Write the file to the specified address
     #[clap(name = "write-memory")]
     WriteMemory {
-        #[clap(parse(try_from_str = parse_int::parse))]
+        #[arg(value_parser = parse_int::parse::<u32>)]
         address: u32,
-        #[clap(parse(from_os_str))]
         file: PathBuf,
     },
     /// Erases all non-secure flash. This MUST be done before writing!
@@ -40,15 +39,14 @@ enum ISPCommand {
     FlashEraseAll,
     /// Erases a portion of non-secure flash. This MUST be done before writing!
     FlashEraseRegion {
-        #[clap(parse(try_from_str = parse_int::parse))]
+        #[arg(value_parser = parse_int::parse::<u32>)]
         start_address: u32,
-        #[clap(parse(try_from_str = parse_int::parse))]
+        #[arg(value_parser = parse_int::parse::<u32>)]
         byte_count: u32,
     },
     /// Write a file to the CMPA region
     #[clap(name = "write-cmpa")]
     WriteCMPA {
-        #[clap(parse(from_os_str))]
         file: PathBuf,
     },
     /// Erase the CMPA region (use to boot non-secure binaries again)
@@ -56,26 +54,22 @@ enum ISPCommand {
     EraseCMPA,
     /// Save the CMPA region to a file
     ReadCMPA {
-        #[clap(parse(from_os_str))]
         file: PathBuf,
     },
     /// Save the CFPA region to a file
     ReadCFPA {
-        #[clap(parse(from_os_str))]
         file: PathBuf,
     },
     /// Write the CFPA region from the contents of a file.
     WriteCFPA {
         #[clap(short, long)]
         update_version: bool,
-        #[clap(parse(from_os_str))]
         file: PathBuf,
     },
     /// Put a minimalist program on to allow attaching via SWD
     Restore,
     /// Send SB update file
     SendSBUpdate {
-        #[clap(parse(from_os_str))]
         file: PathBuf,
     },
     /// Set up key store this involves
@@ -84,7 +78,6 @@ enum ISPCommand {
     /// - Setting SBKEK
     /// - Writing to persistent storage
     SetupKeyStore {
-        #[clap(parse(from_os_str))]
         file: PathBuf,
     },
     /// Trigger a new enrollment in the PUF
@@ -97,11 +90,10 @@ enum ISPCommand {
     EraseKeyStore,
     /// Set the SBKEK, required for SB Updates
     SetSBKek {
-        #[clap(parse(from_os_str))]
         file: PathBuf,
     },
     GetProperty {
-        #[clap(parse(try_from_str))]
+        #[arg(value_parser = BootloaderProperty::from_str)]
         prop: BootloaderProperty,
     },
     LastError,

--- a/lpc55_sign/Cargo.toml
+++ b/lpc55_sign/Cargo.toml
@@ -6,24 +6,24 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-packed_struct = "0.10.0"
-packed_struct_codegen = "0.10.0"
-clap = { version = "4.1.8", features = ["derive"] }
-anyhow = "1.0.32"
-byteorder = "1.3.4"
-ecdsa = { version = "0.16.0", default-features = false, features = ["pkcs8", "der"] }
-p256 = { version = "0.13.0", features = ["pkcs8"] }
-elliptic-curve = { version = "0.13.1", default-features = false }
-hex = "0.4.3"
-crc-any = "2.3.5"
-x509-parser = { version = "0.12.0", features = ["verify"] }
-sha2 = "0.9.8"
-rsa = { version = "0.8.1", features = ["sha2"] }
-lpc55_areas = { path = "../lpc55_areas", features = [] }
-serde = { version = "1", features = ["derive"] }
-toml = "0.5.6"
-parse_int = "0.6.0"
-colored = "2.0"
+anyhow.workspace = true
+byteorder.workspace = true
+clap.workspace = true
+colored.workspace = true
+crc-any.workspace = true
+ecdsa.workspace = true
+elliptic-curve.workspace = true
+hex.workspace = true
+lpc55_areas.workspace = true
+p256.workspace = true
+packed_struct.workspace = true
+packed_struct_codegen.workspace = true
+parse_int.workspace = true
+rsa.workspace = true
+serde.workspace = true
+sha2.workspace = true
+toml.workspace = true
+x509-parser.workspace = true
 
 [features]
 default = ["binaries"]


### PR DESCRIPTION
We were compiling both `clap v3` and `v4`.

This PR consolidates to `v4` by using workspace dependencies everywhere.  It also minimizes features (starting from `default-features = false`), which means it's lighter to include as a dependency elsewhere.