### PR TITLE
Add flag to lock CMPA; implement more CMPA and CFPA checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -462,7 +462,6 @@ version = "0.2.0"
 dependencies = [
  "byteorder",
  "clap",
- "colored",
  "crc-any",
  "env_logger",
  "hex",
@@ -482,6 +481,7 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",
+ "colored",
  "env_logger",
  "log",
  "lpc55_areas",

--- a/lpc55_isp/src/bin/lpc55_flash.rs
+++ b/lpc55_isp/src/bin/lpc55_flash.rs
@@ -271,7 +271,7 @@ fn main() -> Result<()> {
 
             println!("If you didn't already erase the flash this operation will fail!");
             println!("This operation may take a while");
-            let mut infile = std::fs::OpenOptions::new().read(true).open(&file)?;
+            let mut infile = std::fs::OpenOptions::new().read(true).open(file)?;
 
             let mut bytes = Vec::new();
 
@@ -302,7 +302,7 @@ fn main() -> Result<()> {
         ISPCommand::WriteCMPA { file } => {
             do_ping(&mut *port)?;
 
-            let mut infile = std::fs::OpenOptions::new().read(true).open(&file)?;
+            let mut infile = std::fs::OpenOptions::new().read(true).open(file)?;
 
             let mut bytes = Vec::new();
 
@@ -355,7 +355,7 @@ fn main() -> Result<()> {
         } => {
             do_ping(&mut *port)?;
 
-            let bytes = std::fs::read(&file)?;
+            let bytes = std::fs::read(file)?;
             let mut new_cfpa = lpc55_areas::CFPAPage::from_bytes(
                 bytes[..].try_into().context("CFPA file is not 512 bytes")?,
             )?;
@@ -429,7 +429,7 @@ fn main() -> Result<()> {
             do_ping(&mut *port)?;
 
             println!("Sending SB file, this may take a while");
-            let mut infile = std::fs::OpenOptions::new().read(true).open(&file)?;
+            let mut infile = std::fs::OpenOptions::new().read(true).open(file)?;
 
             let mut bytes = Vec::new();
 
@@ -477,7 +477,7 @@ fn main() -> Result<()> {
         ISPCommand::SetSBKek { file } => {
             do_ping(&mut *port)?;
 
-            let mut infile = std::fs::OpenOptions::new().read(true).open(&file)?;
+            let mut infile = std::fs::OpenOptions::new().read(true).open(file)?;
 
             let mut raw_bytes = Vec::new();
 
@@ -502,7 +502,7 @@ fn main() -> Result<()> {
             do_generate_uds(&mut *port)?;
 
             // Step 3: Set the SBKEK
-            let mut infile = std::fs::OpenOptions::new().read(true).open(&file)?;
+            let mut infile = std::fs::OpenOptions::new().read(true).open(file)?;
 
             let mut raw_bytes = Vec::new();
 

--- a/lpc55_sign/Cargo.toml
+++ b/lpc55_sign/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2021"
 [dependencies]
 byteorder.workspace = true
 clap = { workspace = true, optional = true }
-colored.workspace = true
 crc-any.workspace = true
 env_logger.workspace = true
 hex.workspace = true

--- a/lpc55_sign/src/verify.rs
+++ b/lpc55_sign/src/verify.rs
@@ -135,10 +135,8 @@ pub fn verify_image(image: &[u8], cmpa: CMPAPage, cfpa: CFPAPage) -> Result<(), 
     trace!("Image key revoke: {:x}", cfpa.image_key_revoke);
     trace!("{:#?}", rkth_revoke);
 
-    if cfpa.sha256_digest != [0; 32] {
-        error!("CFPA digest is locked, which prevents **any** updates!");
-        failed = true;
-    }
+    // TODO: decide if we want to check CFPA digest
+
     if secure_boot_enabled {
         if (cfpa.dcfg_cc_socu_ns_pin >> 16) as u16 != (!cfpa.dcfg_cc_socu_ns_pin & 0xFFFF) as u16 {
             error!(

--- a/lpc55_sign/src/verify.rs
+++ b/lpc55_sign/src/verify.rs
@@ -82,6 +82,8 @@ pub fn verify_image(image: &[u8], cmpa: CMPAPage, cfpa: CFPAPage) -> Result<(), 
         if expected_hash != cmpa.sha256_digest {
             error!("CMPA digest does not match expected hash");
             failed = true;
+        } else {
+            okay!("CMPA digest matches expected hash");
         }
     } else {
         okay!("CMPA digest is all 0s (unlocked)");

--- a/lpc55_sign/src/verify.rs
+++ b/lpc55_sign/src/verify.rs
@@ -88,15 +88,7 @@ pub fn verify_image(image: &[u8], cmpa: CMPAPage, cfpa: CFPAPage) -> Result<(), 
     trace!("Image key revoke: {:x}", cfpa.image_key_revoke);
     trace!("{:#?}", rkth_revoke);
     if cfpa.sha256_digest != [0; 32] {
-        let cfpa_bytes = cfpa.pack()?;
-        let mut cfpa_sha = sha2::Sha256::new();
-        cfpa_sha.update(&cfpa_bytes[0..cfpa_bytes.len() - 32]);
-        let expected_hash: [u8; 32] = cfpa_sha.finalize().into();
-        if expected_hash != cfpa.sha256_digest {
-            error!("CFPA digest does not match expected hash");
-        }
-    } else {
-        okay!("CFPA digest is all 0s (unlocked)");
+        error!("CFPA digest is locked, which prevents **any** updates!");
     }
 
     info!("=== Image ====");

--- a/lpc55_sign_bin/Cargo.toml
+++ b/lpc55_sign_bin/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 anyhow.workspace = true
 clap.workspace = true
+colored.workspace = true
 env_logger.workspace = true
 log.workspace = true
 lpc55_areas.workspace = true


### PR DESCRIPTION
This allows you to lock the CMPA by specifying `--lock` and agreeing to a warning (or `--lock --yes`).

In addition, it adds more checking to CMPA and CFPA in the `verify-signed-image` subcommand.