### PR TITLE
Fix incorrect speed definitions

### DIFF
--- a/lpc55_areas/src/lib.rs
+++ b/lpc55_areas/src/lib.rs
@@ -402,8 +402,8 @@ impl DefaultIsp {
 #[derive(PrimitiveEnum, Copy, Clone, Debug)]
 pub enum BootSpeed {
     Nmpa = 0b00,
-    Fro48mhz = 0b10,
-    Fro96mhz = 0b01,
+    Fro48mhz = 0b01,
+    Fro96mhz = 0b10,
 }
 
 /// Represents a pin on the LPC55 used to indicate an error during boot


### PR DESCRIPTION
See [the spreadsheet](https://docs.google.com/spreadsheets/d/1jYVbaQ9NoPv4Bjkbv7-xfIGJ_8S9p07D/edit#gid=169257003) for details.

This will require follow-up PRs to `hubtools` and then to `hubris`