### PR TITLE
lpc55_sign: check root and chain certs use supported signature algorithm

### DIFF
--- a/lpc55_sign/src/cert.rs
+++ b/lpc55_sign/src/cert.rs
@@ -1,0 +1,17 @@
+use x509_parser::{
+    certificate::X509Certificate,
+    oid_registry::{self},
+};
+
+pub fn uses_supported_signature_algorithm(cert: &X509Certificate) -> bool {
+    cert.signature_algorithm.algorithm == oid_registry::OID_PKCS1_SHA256WITHRSA
+}
+
+pub fn signature_algorithm_name(cert: &X509Certificate) -> String {
+    let oid_registry = oid_registry::OidRegistry::default().with_crypto();
+    if let Some(x) = oid_registry.get(&cert.signature_algorithm.algorithm) {
+        x.sn().into()
+    } else {
+        cert.signature_algorithm.algorithm.to_string()
+    }
+}

--- a/lpc55_sign/src/lib.rs
+++ b/lpc55_sign/src/lib.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+pub mod cert;
 pub mod crc_image;
 pub mod signed_image;
 pub mod verify;
@@ -55,4 +56,7 @@ pub enum Error {
 
     #[error("public keys have varying sizes (must all be 2048 or 4096 bit)")]
     VaryingPublicKeySizes,
+
+    #[error("certificate with subject {subject} uses unsupported signature algorithm {algorithm}. Only sha256WithRSAEncryption is supported.")]
+    UnsupportedCertificateSignatureAlgorithm { subject: String, algorithm: String },
 }

--- a/lpc55_sign/src/verify.rs
+++ b/lpc55_sign/src/verify.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::Error;
+use crate::{cert, Error};
 use hex::ToHex as _;
 use log::{debug as okay, error, info, trace, warn};
 use lpc55_areas::{
@@ -386,6 +386,14 @@ fn check_signed_image(image: &[u8], cmpa: CMPAPage, cfpa: CFPAPage) -> Result<bo
                 | (RSA4KStatus::RSA4096Only3, 4096)
         ) {
             error!("    Certificate public key size ({public_key_bits} bits) does not match CMPA config ({cmpa_rsa4k:?})");
+            failed = true;
+        }
+
+        if !cert::uses_supported_signature_algorithm(&cert) {
+            error!(
+                "    Unsupported signature algorithm: {}. Only sha256WithRSAEncryption is supported.",
+                cert::signature_algorithm_name(&cert)
+            );
             failed = true;
         }
 


### PR DESCRIPTION
- Move required_key_size into the library so hubtools can use it
- Bump version
- lpc55_sign: check root and chain certs use supported signature algorithm
