### PR TITLE
Move off pre-release rsa crate that broke things

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -668,14 +668,13 @@ dependencies = [
 
 [[package]]
 name = "pkcs1"
-version = "0.7.3"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a80397ccad3b40508254eee787bcd28ba48cb82710de5b33cc40c5b2c21bde9"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
 dependencies = [
  "der",
  "pkcs8",
  "spki",
- "zeroize",
 ]
 
 [[package]]
@@ -790,9 +789,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "rsa"
-version = "0.9.0-pre.2"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65db0998ad35adcaca498b7358992e088ee16cc783fe6fb899da203e113a63e5"
+checksum = "3dd2017d3e6d67384f301f8b06fbf4567afc576430a61624d845eb04d2b30a72"
 dependencies = [
  "byteorder",
  "const-oid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ num-traits = { version = "0.2.15", default-features = false }
 packed_struct = { version = "0.10.1", default-features = false, features = ["std"] }
 parse_int = { version = "0.6.0", default-features = false }
 pem-rfc7468 = { version = "0.7.0", features = ["std"] }
-rsa = { version = "0.9.0-pre.0", default-features = false, features = ["std", "pem", "sha2"] }
+rsa = { version = "0.9.0", default-features = false, features = ["std", "pem", "sha2"] }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serialport = { git = "https://github.com/jgallagher/serialport-rs", branch = "illumos-support", default-features = false }
 sha2 = { version = "0.10", default-features = false }

--- a/lpc55_sign/Cargo.toml
+++ b/lpc55_sign/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lpc55_sign"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/lpc55_sign/src/debug_auth.rs
+++ b/lpc55_sign/src/debug_auth.rs
@@ -1,7 +1,7 @@
 use byteorder::LittleEndian;
 use lpc55_areas::DebugSettings;
 use num_traits::ToPrimitive;
-use rsa::{PublicKeyParts, RsaPrivateKey, RsaPublicKey};
+use rsa::{traits::PublicKeyParts, RsaPrivateKey, RsaPublicKey};
 use sha2::{Digest, Sha256};
 use x509_cert::Certificate;
 use zerocopy::{FromBytes, U16, U32};

--- a/lpc55_sign/src/signed_image.rs
+++ b/lpc55_sign/src/signed_image.rs
@@ -9,7 +9,7 @@ use byteorder::{ByteOrder, LittleEndian};
 use der::Encode as _;
 use lpc55_areas::*;
 use packed_struct::prelude::*;
-use rsa::{PublicKeyParts, RsaPrivateKey};
+use rsa::{traits::PublicKeyParts, RsaPrivateKey};
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
 use x509_cert::Certificate;

--- a/lpc55_sign/src/verify.rs
+++ b/lpc55_sign/src/verify.rs
@@ -14,7 +14,8 @@ use packed_struct::{EnumCatchAll, PackedStruct};
 use rsa::{
     pkcs1v15::{Signature, VerifyingKey},
     signature::Verifier as _,
-    PublicKeyParts, RsaPublicKey,
+    traits::PublicKeyParts,
+    RsaPublicKey,
 };
 use sha2::{Digest as _, Sha256};
 use std::io::Write as _;


### PR DESCRIPTION
lpc55_sign was using the rsa 0.9.0-pre.0 crate, which (when people use it as a library) would select the 0.9.0 released version. Unfortunately the released version contains API incompatibilities with pre.0, breaking builds. (This is one of the reasons why depending on prerelease crates is a bad idea.)

This switches to the released 0.9.0 and fixes the incompatibilities that resulted, which came down to a single trait being moved into a module.

I've bumped the crate version number so that people can depend on a known-working version, and because recent commits have changed some signing API incompatibly.