### PR TITLE
Revert "Fix incorrect speed definitions"

### DIFF
--- a/lpc55_areas/Cargo.toml
+++ b/lpc55_areas/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lpc55_areas"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 
 [dependencies]

--- a/lpc55_areas/src/lib.rs
+++ b/lpc55_areas/src/lib.rs
@@ -430,8 +430,8 @@ impl DefaultIsp {
 #[derive(PrimitiveEnum, Copy, Clone, Debug)]
 pub enum BootSpeed {
     Nmpa = 0b00,
-    Fro48mhz = 0b01,
-    Fro96mhz = 0b10,
+    Fro48mhz = 0b10,
+    Fro96mhz = 0b01,
 }
 
 /// Represents a pin on the LPC55 used to indicate an error during boot


### PR DESCRIPTION
This reverts commit c8a7814e4452e63c4cb118101a424a670a6ba95c.

It appears that the NXP spreadsheet we were following when we made this change is, itself, incorrect. Tested 2023-05-16 on a 1B rev 55S69.