### PR TITLE
lpc55_sign cmdline ergonomics improvements.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "addr2line"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -86,6 +101,9 @@ name = "anyhow"
 version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
+dependencies = [
+ "backtrace",
+]
 
 [[package]]
 name = "atty"
@@ -103,6 +121,21 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "backtrace"
+version = "0.3.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
 
 [[package]]
 name = "base64ct"
@@ -183,6 +216,7 @@ dependencies = [
  "bitflags",
  "clap_lex",
  "strsim",
+ "terminal_size",
 ]
 
 [[package]]
@@ -353,6 +387,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -456,7 +496,7 @@ dependencies = [
 
 [[package]]
 name = "lpc55_areas"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "bitfield",
  "packed_struct",
@@ -551,6 +591,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
+dependencies = [
+ "adler",
+]
+
+[[package]]
 name = "nix"
 version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -618,6 +667,15 @@ checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "object"
+version = "0.30.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea86265d3d3dcb6a27fc51bd29a4bf387fae9d2986b823079d4986af253eb439"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -810,6 +868,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+
+[[package]]
 name = "rustix"
 version = "0.37.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -982,6 +1046,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e6bf6f19e9f8ed8d4048dc22981458ebcf406d67e94cd422e5ecd73d63b3237"
+dependencies = [
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,10 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-anyhow = { version = "1", default-features = false, features = ["std"] }
+anyhow = { version = "1", default-features = false, features = ["std", "backtrace"] }
 bitfield = { version = "0.14.0", default-features = false }
 byteorder = { version = "1.4.3", default-features = false, features = ["std"] }
-clap = { version = "4", default-features = false, features = ["std", "derive", "default"] }
+clap = { version = "4", default-features = false, features = ["std", "derive", "default", "wrap_help"] }
 colored = { version = "2.0", default-features = false }
 const-oid = { version = "0.9.2", default-features = false }
 crc-any = { version = "2.4.3", default-features = false }

--- a/lpc55_sign/src/signed_image.rs
+++ b/lpc55_sign/src/signed_image.rs
@@ -10,15 +10,17 @@ use der::Encode as _;
 use lpc55_areas::*;
 use packed_struct::prelude::*;
 use rsa::{traits::PublicKeyParts, RsaPrivateKey};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use x509_cert::Certificate;
 
-#[derive(Clone, Debug, Deserialize)]
+/// Struct defining the TOML format for `--cert-cfg`, which bundles up flags
+/// that would otherwise need to appear on the command line.
+#[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct CertConfig {
     /// The file containing the private key with which to sign the image.
-    pub private_key: PathBuf,
+    pub private_key: Option<PathBuf>,
 
     /// The chain of DER-encoded signing certificate files, in root-to-leaf
     /// order. The image will be signed with the private key corresponding

--- a/lpc55_sign_bin/Cargo.toml
+++ b/lpc55_sign_bin/Cargo.toml
@@ -16,7 +16,7 @@ log.workspace = true
 lpc55_areas.workspace = true
 lpc55_sign = { workspace = true, features = ["clap"] }
 pem-rfc7468.workspace = true
-toml = { workspace = true, features = ["parse"] }
+toml = { workspace = true, features = ["parse", "display"] }
 x509-cert.workspace = true
 zerocopy.workspace = true
 


### PR DESCRIPTION
- Documented a bunch more flags.

- Made private keys, which are not required by all commands, optional both on the command line and in the TOML cfg files.

- Allowed for multiple root certs to be passed on the command line, for symmetry with the TOML interface.

- Documented the structure of the TOML file in the command line help to keep the user from needing to find and interpret the source code.

- Added comments to the struct defining the TOML file format to make it easier on a user who decides to do it anyway.

- Added gen-cert-cfg subcommand that will generate the TOML format for you based on flags, to make writing the file less error prone.

- Improved flag documentation, explaining which are mutually exclusive with which others.

- Turned on help wrapping to terminal width.