### PR TITLE
Change the default ISP setting in CMPA to UART.

### DIFF
--- a/lpc55_sign_bin/src/main.rs
+++ b/lpc55_sign_bin/src/main.rs
@@ -346,7 +346,7 @@ fn main() -> Result<()> {
                     dice_args,
                     !without_secure_boot,
                     debug_settings,
-                    DefaultIsp::Auto,
+                    DefaultIsp::Uart,
                     BootSpeed::Fro96mhz,
                     BootErrorPin::new(boot_err_port, boot_err_pin).ok_or_else(|| {
                         anyhow!("invalid boot port: {boot_err_port}:{boot_err_pin}")


### PR DESCRIPTION
The previous choice of "Auto" authorizes the ROM to auto-detect connected interfaces. Since we know there's at least one exploitable bug in the USB bootloader, we really don't want the USB interface to be activated.

One could imagine making this a flag, but, given that we're hardcoding our preferred clock frequency in the line above, I went for expedience.