### PR TITLE
`lpc55_isp` API/error improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -521,7 +521,7 @@ dependencies = [
 
 [[package]]
 name = "lpc55_isp"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -537,6 +537,7 @@ dependencies = [
  "sha2",
  "strum",
  "strum_macros",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ serialport = { git = "https://github.com/jgallagher/serialport-rs", branch = "il
 sha2 = { version = "0.10", default-features = false }
 strum = { version = "0.24", default-features = false, features = ["std"] }
 strum_macros = { version = "0.24", default-features = false }
-thiserror = { version = "1", default-features = false }
+thiserror = { version = "1" }
 toml = { version = "0.7.3", default-features = false }
 x509-cert = { version = "0.2.1", default-features = false, features = ["std"] }
 lpc55_areas = { path = "lpc55_areas", default-features = false }

--- a/lpc55_isp/Cargo.toml
+++ b/lpc55_isp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lpc55_isp"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -20,6 +20,7 @@ serialport.workspace = true
 sha2.workspace = true
 strum.workspace = true
 strum_macros.workspace = true
+thiserror.workspace = true
 
 [features]
 default = ["binaries"]

--- a/lpc55_isp/src/bin/cfpa-update.rs
+++ b/lpc55_isp/src/bin/cfpa-update.rs
@@ -74,7 +74,7 @@ fn main() -> Result<()> {
     } else {
         println!("Writing updated CFPA region back to the device");
 
-        do_isp_write_memory(&mut *port, 0x9de00, updated.to_vec())?;
+        do_isp_write_memory(&mut *port, 0x9de00, &updated)?;
         println!("done!");
     }
 

--- a/lpc55_isp/src/cmd.rs
+++ b/lpc55_isp/src/cmd.rs
@@ -3,7 +3,6 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use crate::isp::*;
-use anyhow::Result;
 
 enum DataPhase<'a> {
     NoData,
@@ -17,7 +16,7 @@ fn do_command(
     command_resp: ResponseCode,
     args: impl Into<Vec<u32>>,
     d: DataPhase,
-) -> Result<Option<Vec<u8>>> {
+) -> Result<Option<Vec<u8>>, IspError> {
     send_command(port, tag, args)?;
 
     read_response(port, command_resp)?;
@@ -39,7 +38,7 @@ fn do_command(
     Ok(ret)
 }
 
-pub fn do_save_keystore(port: &mut dyn serialport::SerialPort) -> Result<()> {
+pub fn do_save_keystore(port: &mut dyn serialport::SerialPort) -> Result<(), IspError> {
     do_command(
         port,
         CommandTag::KeyProvision,
@@ -56,7 +55,7 @@ pub fn do_save_keystore(port: &mut dyn serialport::SerialPort) -> Result<()> {
     Ok(())
 }
 
-pub fn do_enroll(port: &mut dyn serialport::SerialPort) -> Result<()> {
+pub fn do_enroll(port: &mut dyn serialport::SerialPort) -> Result<(), IspError> {
     do_command(
         port,
         CommandTag::KeyProvision,
@@ -68,7 +67,7 @@ pub fn do_enroll(port: &mut dyn serialport::SerialPort) -> Result<()> {
     Ok(())
 }
 
-pub fn do_generate_uds(port: &mut dyn serialport::SerialPort) -> Result<()> {
+pub fn do_generate_uds(port: &mut dyn serialport::SerialPort) -> Result<(), IspError> {
     do_command(
         port,
         CommandTag::KeyProvision,
@@ -87,7 +86,10 @@ pub fn do_generate_uds(port: &mut dyn serialport::SerialPort) -> Result<()> {
     Ok(())
 }
 
-pub fn do_isp_write_keystore(port: &mut dyn serialport::SerialPort, data: &[u8]) -> Result<()> {
+pub fn do_isp_write_keystore(
+    port: &mut dyn serialport::SerialPort,
+    data: &[u8],
+) -> Result<(), IspError> {
     do_command(
         port,
         CommandTag::KeyProvision,
@@ -102,7 +104,7 @@ pub fn do_isp_write_keystore(port: &mut dyn serialport::SerialPort, data: &[u8])
     Ok(())
 }
 
-pub fn do_recv_sb_file(port: &mut dyn serialport::SerialPort, data: &[u8]) -> Result<()> {
+pub fn do_recv_sb_file(port: &mut dyn serialport::SerialPort, data: &[u8]) -> Result<(), IspError> {
     do_command(
         port,
         CommandTag::ReceiveSbFile,
@@ -121,7 +123,7 @@ pub fn do_isp_set_userkey(
     port: &mut dyn serialport::SerialPort,
     key_type: KeyType,
     data: &[u8],
-) -> Result<()> {
+) -> Result<(), IspError> {
     do_command(
         port,
         CommandTag::KeyProvision,
@@ -147,7 +149,7 @@ pub fn do_isp_read_memory(
     port: &mut dyn serialport::SerialPort,
     address: u32,
     cnt: u32,
-) -> Result<Vec<u8>> {
+) -> Result<Vec<u8>, IspError> {
     let f = do_command(
         port,
         CommandTag::ReadMemory,
@@ -171,7 +173,7 @@ pub fn do_isp_write_memory(
     port: &mut dyn serialport::SerialPort,
     address: u32,
     data: &[u8],
-) -> Result<()> {
+) -> Result<(), IspError> {
     do_command(
         port,
         CommandTag::WriteMemory,
@@ -193,7 +195,7 @@ pub fn do_isp_write_memory(
     Ok(())
 }
 
-pub fn do_isp_flash_erase_all(port: &mut dyn serialport::SerialPort) -> Result<()> {
+pub fn do_isp_flash_erase_all(port: &mut dyn serialport::SerialPort) -> Result<(), IspError> {
     do_command(
         port,
         CommandTag::FlashEraseAll,
@@ -212,7 +214,7 @@ pub fn do_isp_flash_erase_region(
     port: &mut dyn serialport::SerialPort,
     start_address: u32,
     byte_count: u32,
-) -> Result<()> {
+) -> Result<(), IspError> {
     do_command(
         port,
         CommandTag::FlashEraseRegion,
@@ -232,7 +234,7 @@ pub fn do_isp_flash_erase_region(
 pub fn do_isp_get_property(
     port: &mut dyn serialport::SerialPort,
     prop: BootloaderProperty,
-) -> Result<Vec<u32>> {
+) -> Result<Vec<u32>, IspError> {
     send_command(port, CommandTag::GetProperty, [prop as u32])?;
 
     let f = read_response(port, ResponseCode::GetProperty)?;
@@ -240,7 +242,7 @@ pub fn do_isp_get_property(
     Ok(f)
 }
 
-pub fn do_isp_last_error(port: &mut dyn serialport::SerialPort) -> Result<Vec<u32>> {
+pub fn do_isp_last_error(port: &mut dyn serialport::SerialPort) -> Result<Vec<u32>, IspError> {
     send_command(
         port,
         CommandTag::GetProperty,

--- a/lpc55_isp/src/isp.rs
+++ b/lpc55_isp/src/isp.rs
@@ -195,7 +195,9 @@ pub struct CommandPacket {
 }
 
 impl CommandPacket {
-    fn new_command(c: CommandTag, args: Vec<u32>) -> CommandPacket {
+    fn new_command(c: CommandTag, args: impl Into<Vec<u32>>) -> CommandPacket {
+        let args = args.into();
+
         let mut v = VariablePacket {
             packet: FramingPacket::new(PacketType::Command),
             raw_command: RawCommand::new(c, args.len()),
@@ -458,7 +460,7 @@ pub fn read_response(
 pub fn send_command(
     port: &mut dyn serialport::SerialPort,
     cmd: CommandTag,
-    args: Vec<u32>,
+    args: impl Into<Vec<u32>>,
 ) -> Result<(), IspError> {
     let command_bytes = CommandPacket::new_command(cmd, args).to_bytes();
 
@@ -501,7 +503,7 @@ pub fn recv_data(port: &mut dyn serialport::SerialPort, cnt: u32) -> Result<Vec<
 pub fn do_isp_write_memory(
     port: &mut dyn serialport::SerialPort,
     address: u32,
-    data: Vec<u8>,
+    data: &[u8],
 ) -> Result<(), IspError> {
     let len = u32::try_from(data.len()).expect("can't send more than 4 GiB");
     let args = vec![address, len, 0x0];

--- a/lpc55_sign/src/verify.rs
+++ b/lpc55_sign/src/verify.rs
@@ -243,16 +243,10 @@ pub fn verify_image(image: &[u8], cmpa: CMPAPage, cfpa: CFPAPage) -> Result<(), 
     let image_type = BootField::unpack(image[0x24..0x28].try_into().unwrap())?;
 
     let load_addr = u32::from_le_bytes(image[0x34..0x38].try_into().unwrap());
-    let is_plain = image_type.img_type == EnumCatchAll::Enum(BootImageType::PlainImage);
 
     trace!("image length: {image_len:#x} ({image_len})");
     trace!("image type: {image_type:#?}");
     trace!("load address: {load_addr:#x}");
-    if is_plain && load_addr != 0 {
-        warn!("Load address is non-0 in a plain image",);
-    } else if !is_plain && load_addr == 0 {
-        warn!("Load address is 0 in a non-plain image",);
-    }
 
     info!("Checking TZM configuration");
     match secure_boot_cfg.tzm_image_type {


### PR DESCRIPTION
Broadly, this

- Moves errors to a pattern-matchable error type instead of the stringly-typed `anyhow::Error`
- Loosens types for function arguments from `Vec` to slice or, where a `Vec` could usefully be passed by value, `impl Into<Vec<Whatever>>`.
- Firms up error handling choices around input/programmer errors vs runtime errors, and asserts on more of the former, eliminating otherwise spurious and hard-to-handle errors from the new error type.
- Cleans up some cases where a standard library function can make an operation less error prone or verbose (e.g. `std::fs::read` and friends).