### PR TITLE
Subcommand to generate ROTKH from certificates

### DIFF
--- a/lpc55_sign_bin/src/main.rs
+++ b/lpc55_sign_bin/src/main.rs
@@ -290,7 +290,7 @@ struct CertArgs {
     ///
     /// Cannot be combined with the `--cert-cfg` option.
     #[clap(long)]
-    root_cert: Option<PathBuf>,
+    root_cert: Vec<PathBuf>,
 
     /// Path to a TOML file specifying the cert configuration. This file can
     /// contain three top-level keys, all optional. `private-key` gives the path

--- a/lpc55_sign_bin/src/main.rs
+++ b/lpc55_sign_bin/src/main.rs
@@ -273,6 +273,11 @@ enum Command {
         #[clap(long, short)]
         raw: bool,
     },
+    /// Generate RKTH and ROTKH for a set of root certificates
+    GenRootHashes {
+        #[clap(flatten)]
+        certs: CertArgs,
+    },
 }
 
 #[derive(Debug, Parser)]
@@ -783,6 +788,18 @@ fn main() -> Result<()> {
                 println!();
                 println!("--- END CFPA CONTENTS ---");
             }
+        }
+        Command::GenRootHashes { certs } => {
+            let cfg: CertConfig = certs.try_into_config()?;
+            let root_certs = pad_roots(read_certs(&cfg.root_certs)?)?;
+
+            for (i, cert) in root_certs.iter().enumerate() {
+                let rkth = signed_image::root_key_hash(cert.as_ref())?;
+                println!("rkth{i} = {}", hex::encode(rkth));
+            }
+
+            let rotkh = signed_image::root_key_table_hash(&root_certs)?;
+            println!("rotkh = {}", hex::encode(rotkh));
         }
     }
 


### PR DESCRIPTION
- lpc55_sign: allow --root-cert to be specified multiple times
- lpc55_sign: subcommand for generating ROTKH from certificates
