### PR TITLE
Update lock file w/ latest versions from lpc55_areas & lpc55_sign.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -511,7 +511,7 @@ dependencies = [
 
 [[package]]
 name = "lpc55_areas"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "bitfield",
  "clap",
@@ -542,7 +542,7 @@ dependencies = [
 
 [[package]]
 name = "lpc55_sign"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "byteorder",
  "clap",


### PR DESCRIPTION
We missed updating `Cargo.lock` the last time versions were bumped on `lpc55_areas` and `lpc55_sign`.