### PR TITLE
Fail github action if source tree is dirty

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,3 +44,5 @@ jobs:
         with:
           command: build
 
+      - name: Dirty worktree check
+        run: git diff HEAD --exit-code


### PR DESCRIPTION
This is a cheap check to see if Cargo.lock was change w/o being checked in.

This should fail till #87 is merged.