### PR TITLE
Add `measurement-token` crate

### DIFF
--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -12,5 +12,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@nightly
         with:
           components: rustfmt
-      - name: cargo fmt 
-        run: cargo fmt --all -- --check
+      - name: cargo fmt
+        run: |
+          rustup component add rustfmt
+          cargo fmt --all -- --check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -599,6 +599,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 
 [[package]]
+name = "measurement-token"
+version = "0.1.0"
+
+[[package]]
 name = "memchr"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "lpc55_sign",
     "lpc55_sign_bin",
     "lpc55_isp",
+    "measurement_token",
 ]
 resolver = "2"
 

--- a/measurement_token/Cargo.toml
+++ b/measurement_token/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "measurement-token"
+version = "0.1.0"
+edition = "2021"

--- a/measurement_token/src/lib.rs
+++ b/measurement_token/src/lib.rs
@@ -1,0 +1,40 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//! A measurement token tells the SP that it has been measured
+//!
+//! For various reasons (see RFD 568), the RoT is not allowed to proactively
+//! reset the SP; it can only catch the SP during a reset and hold it for
+//! measurements.  However, during initial power-on, the SP boots faster than
+//! the RoT.  What are we to do?
+//!
+//! RFD 568 proposes a coordination mechanism: the SP will reset itself a few
+//! times, until either a retry count is exceeded or it boots with a token
+//! deposited in a particular memory location (indicating that it has been
+//! measured).
+//!
+//! This crate defines constants to implement this coordination mechanism.
+//! These constants are shared between the RoT `SpCtrl` task, the SP's kernel,
+//! and the Humility debugger.
+//!
+//! The 32-bit values are chosen arbitrarily from hashes of sentences; we just
+//! need something that's not likely to be in RAM by accident.
+#![no_std]
+
+/// Address at which the measurement token can be found
+///
+/// This is DTCM RAM on the STM32H7, which is not used by any of our production
+/// firmware.  In Hubris, the kernel build script is responsible for ensuring
+/// that this memory is available.
+pub const SP_ADDR: *mut u32 = 0x2000_0000 as *mut u32;
+
+/// A valid measurement has been made and booting can continue
+///
+/// This value should only be written by the RoT
+pub const VALID: u32 = 0xc887a12;
+
+/// No measurement has been made, but booting should continue
+///
+/// This value is written by an attached debugger, which otherwise prevents
+/// measurements because it's attached the SWD port.
+pub const SKIP: u32 = 0x9f38bd71;


### PR DESCRIPTION
This crate defines constants to be shared between the SP, RoT, and Humility.

Questions
- [ ] Is 32 bits enough, or should we use wider words?
- [ ] Should we use human-readable values (e.g. `b"DONE"` / `b"SKIP"`), per [this comment](https://github.com/oxidecomputer/hubris/pull/2138#discussion_r2198453812)?