### PR TITLE
Consolidate signed image decoding

### DIFF
--- a/lpc55_areas/src/lib.rs
+++ b/lpc55_areas/src/lib.rs
@@ -3,10 +3,18 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use std::fmt::Debug;
+use std::ops::Range;
 
 use packed_struct::prelude::*;
 use packed_struct::PackingError;
 use serde::{Deserialize, Serialize};
+
+// Fig 17, section 7.3.4
+pub const HEADER_IMAGE_LENGTH: Range<usize> = 0x20..0x24;
+pub const HEADER_IMAGE_TYPE: Range<usize> = 0x24..0x28;
+pub const HEADER_OFFSET: Range<usize> = 0x28..0x2c;
+pub const HEADER_LOAD_ADDR: Range<usize> = 0x34..0x38;
+pub const HEADER_SIGNATURE: [u8; 4] = *b"cert";
 
 // Table 183, section 7.3.4
 #[derive(PrimitiveEnum, Copy, Clone, Debug, Eq, PartialEq)]
@@ -666,7 +674,7 @@ impl CertHeader {
     pub fn new(cert_header_size: usize, cert_table_len: usize) -> CertHeader {
         CertHeader {
             // This 'signature' is just a simple marker
-            signature: *b"cert",
+            signature: HEADER_SIGNATURE,
             header_version: 1,
             header_length: cert_header_size as u32,
             // Need to be 0 for now

--- a/lpc55_sign/src/lib.rs
+++ b/lpc55_sign/src/lib.rs
@@ -151,7 +151,10 @@ pub enum Error {
     MissingCertHeader,
 
     #[error("Invalid image length in cert header: expected {0}, got {1}")]
-    InvalidImageLen(u32, u32),
+    InvalidCertBlockLen(u32, u32),
+
+    #[error("Invalid total image length: expected {0}, got {1}")]
+    InvalidImageLen(usize, u32),
 
     #[error("Certificate public key size ({0} bits) does not match CMPA config ({1})")]
     InvalidPubkeySize(usize, usize),

--- a/lpc55_sign/src/lib.rs
+++ b/lpc55_sign/src/lib.rs
@@ -156,6 +156,9 @@ pub enum Error {
     #[error("Certificate public key size ({0} bits) does not match CMPA config ({1})")]
     InvalidPubkeySize(usize, usize),
 
+    #[error("Signature offset {0} != total image length {1}")]
+    InvalidSignatureOffset(usize, u32),
+
     #[error("Unsupported signature algorithm: {0}. Only sha256WithRSAEncryption is supported.")]
     UnsupportedAlgorithm(String),
 
@@ -195,4 +198,7 @@ pub enum Error {
 
     #[error("fmt error: {0}")]
     FmtError(#[from] std::fmt::Error),
+
+    #[error(transparent)]
+    TryFromSliceError(#[from] std::array::TryFromSliceError),
 }

--- a/lpc55_sign/src/lib.rs
+++ b/lpc55_sign/src/lib.rs
@@ -201,7 +201,4 @@ pub enum Error {
 
     #[error("fmt error: {0}")]
     FmtError(#[from] std::fmt::Error),
-
-    #[error(transparent)]
-    TryFromSliceError(#[from] std::array::TryFromSliceError),
 }

--- a/lpc55_sign/src/signed_image.rs
+++ b/lpc55_sign/src/signed_image.rs
@@ -438,9 +438,9 @@ pub fn image_certs_and_sig(image: &[u8]) -> Result<(CertBlock, Sha256, Signature
     let mut offset = (header_offset + header.header_length) as usize;
     let mut certs: Vec<Certificate> = Vec::new();
     for _ in 0..header.certificate_count {
-        let length = u32::from_le_bytes(image[offset..offset + 4].try_into()?);
+        let length = u32::from_le_bytes(image[offset..][..4].try_into()?);
         offset += 4;
-        let cert = cert::read_from_slice(&image[offset..offset + length as usize])?;
+        let cert = cert::read_from_slice(&image[offset..][..length as usize])?;
         certs.push(cert);
         offset += length as usize;
     }
@@ -449,7 +449,7 @@ pub fn image_certs_and_sig(image: &[u8]) -> Result<(CertBlock, Sha256, Signature
     let mut root_key_table = [[0u8; 32]; 4];
     let mut rkth = Sha256::new();
     for slot in root_key_table.iter_mut() {
-        let hash = &image[offset..offset + 32];
+        let hash = &image[offset..][..32];
         rkth.update(hash);
         *slot = hash.try_into()?;
         offset += 32;

--- a/lpc55_sign/src/signed_image.rs
+++ b/lpc55_sign/src/signed_image.rs
@@ -383,7 +383,7 @@ pub fn remove_image_signature(mut img: Vec<u8>) -> Result<Vec<u8>, Error> {
 
 /// Computed from an LPC55 signed image: the certificate header, X.509
 /// certificates, and the root key table & its hash. See UM11126 §7.35.
-pub struct CertBlock {
+pub(crate) struct CertBlock {
     /// Certificate header; see UM11126 Fig 18.
     pub header: CertHeader,
 
@@ -404,7 +404,7 @@ pub struct CertBlock {
 /// it, a hash of the image contents (not including the signature), and the
 /// purported signature of that hash. Does *not* validate the signature or
 /// the certificates, only checks that they decode ok.
-pub fn image_certs_and_sig(image: &[u8]) -> Result<(CertBlock, Sha256, Signature), Error> {
+pub(crate) fn image_certs_and_sig(image: &[u8]) -> Result<(CertBlock, Sha256, Signature), Error> {
     // Check the image type.
     let boot_field = BootField::unpack(image[HEADER_IMAGE_TYPE].try_into().unwrap())?;
     if !matches!(
@@ -489,11 +489,4 @@ pub fn image_certs_and_sig(image: &[u8]) -> Result<(CertBlock, Sha256, Signature
     let signature = Signature::try_from(&image[offset..])?;
 
     Ok((cert_block, digest, signature))
-}
-
-/// Compute and return the Root Key Table Hash (RKTH)
-/// from an LPC55 signed image.
-pub fn image_rkth(image: &[u8]) -> Result<[u8; 32], Error> {
-    let (cert_block, _digest, _signature) = image_certs_and_sig(image)?;
-    Ok(cert_block.root_key_table_hash)
 }

--- a/lpc55_sign/src/verify.rs
+++ b/lpc55_sign/src/verify.rs
@@ -205,9 +205,9 @@ pub fn verify_image(image: &[u8], cmpa: CMPAPage, cfpa: CFPAPage) -> Result<(), 
 
 pub fn print_image(image: &[u8]) -> Result<(), Error> {
     info!("=== Image ====");
-    let image_len = u32::from_le_bytes(image[HEADER_IMAGE_LENGTH].try_into()?);
-    let image_type = BootField::unpack(image[HEADER_IMAGE_TYPE].try_into()?)?;
-    let load_addr = u32::from_le_bytes(image[HEADER_LOAD_ADDR].try_into()?);
+    let image_len = u32::from_le_bytes(image[HEADER_IMAGE_LENGTH].try_into().unwrap());
+    let image_type = BootField::unpack(image[HEADER_IMAGE_TYPE].try_into().unwrap())?;
+    let load_addr = u32::from_le_bytes(image[HEADER_LOAD_ADDR].try_into().unwrap());
     info!("image length: {image_len:#x} ({image_len})");
     info!("image type: {image_type:#?}");
     info!("load address: {load_addr:#x}");
@@ -251,7 +251,7 @@ pub fn print_image(image: &[u8]) -> Result<(), Error> {
             );
         }
         EnumCatchAll::Enum(BootImageType::CRCImage) => {
-            let crc = u32::from_le_bytes(image[HEADER_OFFSET].try_into()?);
+            let crc = u32::from_le_bytes(image[HEADER_OFFSET].try_into().unwrap());
             info!("Expected CRC: {:x}", crc);
         }
         EnumCatchAll::Enum(BootImageType::PlainImage) => (),
@@ -451,7 +451,7 @@ fn check_signed_image(image: &[u8], cmpa: CMPAPage, cfpa: CFPAPage) -> Result<()
         ));
     }
 
-    let last_cert_sn_revoke_id = u16::from_le_bytes(last_cert_sn[2..4].try_into()?);
+    let last_cert_sn_revoke_id = u16::from_le_bytes(last_cert_sn[2..4].try_into().unwrap());
     if !crate::is_unary(last_cert_sn_revoke_id) {
         warn!("Last certificate's revocation ID (0x{last_cert_sn_revoke_id:04x}) should be a unary counter but isn't")
     }
@@ -479,7 +479,7 @@ fn check_crc_image(image: &[u8]) -> Result<(), Error> {
     crc.digest(&image[..HEADER_OFFSET.start]);
     crc.digest(&image[HEADER_OFFSET.end..]);
     let expected = crc.get_crc();
-    let actual = u32::from_le_bytes(image[HEADER_OFFSET].try_into()?);
+    let actual = u32::from_le_bytes(image[HEADER_OFFSET].try_into().unwrap());
     if expected != actual {
         return Err(Error::BadCrc);
     }


### PR DESCRIPTION
There were previously two distinct, slightly different LPC55 signed image decoders (one in `print_image` and one in `check_signed_image`), and neither was panic-free or usable to extract just the RKTH, which we're interested in for oxidecomputer/omicron#8630. This PR merges those into one routine (`image_certs_and_sig`, happy to iterate on the name) that returns a structured certificate block, the digest of the entire image sans signature, and the signature. From these we can easily either verify the signature or return the RKTH (see `image_rkth`). It also adds named constants for all the important image offset ranges.

Tested manually via `lpc55_sign verify-signed-image` and `print-image` with a Bartleby-signed Bootleby image.

Tagging everyone that I know of that's touched these routines; please feel free to ignore. But since we have no automatic tests, running `lpc55_sign` from this branch on your favorite signed image and reporting the results would be appreciated!