### PR TITLE
Check for root key table hash mismatch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -489,7 +489,7 @@ dependencies = [
 
 [[package]]
 name = "lpc55_sign"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "byteorder",
  "clap",

--- a/lpc55_sign/Cargo.toml
+++ b/lpc55_sign/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lpc55_sign"
-version = "0.3.4"
+version = "0.3.5"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/lpc55_sign/src/verify.rs
+++ b/lpc55_sign/src/verify.rs
@@ -375,6 +375,10 @@ pub fn print_cfpa(cfpa: CFPAPage) -> Result<(), Error> {
 fn check_signed_image(image: &[u8], cmpa: CMPAPage, cfpa: CFPAPage) -> Result<(), Error> {
     let (cert_block, digest, signature) = image_certs_and_sig(image)?;
 
+    if cert_block.root_key_table_hash != cmpa.rotkh {
+        return Err(Error::RotkhMismatch);
+    }
+
     let mut prev_public_key = None;
     for cert in cert_block.certs.iter() {
         let cmpa_rsa4k = cmpa.get_secure_boot_cfg()?.rsa4k;


### PR DESCRIPTION
Commit `f05c063e4b68926069efa0edb1159c8a2dbd9253` factored out some of the code for calculating the root key table hash but missed adding the final check against the CMPA. Bring it back.